### PR TITLE
Add `run --once` option and exit with a status code

### DIFF
--- a/lib/run/coordinator.js
+++ b/lib/run/coordinator.js
@@ -16,15 +16,19 @@ const { assign } = Object;
 export default class Coordinator {
   constructor({
     browsers = [],
+    plugins = [],
     reporter = 'dot',
     serve = false,
     serveUrl = 'http://localhost:3000',
     logLevel = 'info',
-    plugins = [],
+    once = false,
     client: clientOptions = {},
     proxy: proxyOptions = {},
+    exit = () => {},
     ...options
   } = {}) {
+    this.exit = exit;
+
     // initialize logger and reporter
     this.log = logger({ name: 'BigTest', level: logLevel });
     this.reporter = new (requireReporter(reporter))();
@@ -86,7 +90,8 @@ export default class Coordinator {
         this.sockets.send(meta.id, 'proxy:connected', this.proxy.url);
       });
 
-    this.sockets // adapter API
+    // Adapter API
+    this.sockets
       .on('adapter/connect', (meta) => {
         this.sockets.send(meta.id, 'run');
       })
@@ -98,6 +103,7 @@ export default class Coordinator {
       })
       .on('adapter/end', (meta) => {
         this.reporter.handleEnd(meta);
+        if (once) this.stop(this.reporter.status);
       });
   }
 
@@ -113,7 +119,7 @@ export default class Coordinator {
       // catch errors and cleanup
     } catch (err) {
       this.log.error(err);
-      await this.stop();
+      await this.stop(1);
     }
   }
 
@@ -164,9 +170,9 @@ export default class Coordinator {
     }));
   }
 
-  async stop() {
+  async stop(status = 0) {
     this.log.newLine();
-    this.log.info('Shutting down...');
+    this.log.debug('Shutting down...');
 
     // kill all browsers
     await Promise.all(this.launchers.map(browser => {
@@ -183,8 +189,10 @@ export default class Coordinator {
 
     // kill serve command
     if (this.serve && this.serve.running) {
-      this.log.info(`Stopping "${this.serve.name}"...`);
+      this.log.debug(`Stopping "${this.serve.name}"...`);
       await this.serve.kill();
     }
+
+    return this.exit(status);
   }
 }

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -1,6 +1,8 @@
 import Coordinator from './coordinator';
 import { getDefaultBrowser } from './util/browsers';
 
+const { assign } = Object;
+
 export function builder(yargs) {
   yargs
     .option('browsers', {
@@ -14,6 +16,12 @@ export function builder(yargs) {
           ? browsers.split(',')
           : browsers;
       }
+    })
+    .option('once', {
+      group: 'Options:',
+      description: 'Run once and exit',
+      type: 'boolean',
+      default: false
     })
     .option('client.hostname', {
       group: 'Client Options:',
@@ -58,7 +66,10 @@ export function builder(yargs) {
 }
 
 export function handler(argv) {
-  let c = new Coordinator(argv);
+  let c = new Coordinator(assign({}, argv, {
+    exit: process.exit
+  }));
+
   process.on('SIGINT', () => c.stop());
   c.start();
 }

--- a/lib/run/reporters/dot.js
+++ b/lib/run/reporters/dot.js
@@ -10,6 +10,7 @@ export default class DotReporter extends BaseReporter {
     }
 
     this.tests = [];
+    this.status = 0;
   }
 
   handleTestEnd(meta, test) {
@@ -41,6 +42,8 @@ export default class DotReporter extends BaseReporter {
     }
 
     if (failing.length) {
+      this.status = 1;
+
       this.newLine()
         .log(chalk.white.bold.underline(`FAILED TESTS:`));
 


### PR DESCRIPTION
## Purpose

As the title says, this adds a `--once` option to the `run` command so that once the tests finish running, the process will exit.

This is just an MVP and probably won't work when multiple browsers are connected because it will exit when the first one finishes. Once we have some proper state in place we can wait for all browsers to be done before exiting.

## Approach

Pass `process.exit` to the coordinator so it can be called with a status code upon stopping.

Add a `status` property to the reporter so that when there are test errors, it can exit with a non-zero (this will likely change in the future once reporters are more stable).

When the test ends, stop the coordinator with the reporter's status so that it can exit with it.

### Todo

- Add slightly more robust state so that reporters have a little more than just `tests = [...]`. This way the we can track browsers and eventually turn this simple state into something much better later on.