### PR TITLE
Add opts option for run command

### DIFF
--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -1,3 +1,6 @@
+import { readFileSync } from 'fs';
+import parse from 'yargs-parser';
+
 import Coordinator from './coordinator';
 import { getDefaultBrowser } from './util/browsers';
 
@@ -22,6 +25,17 @@ export function builder(yargs) {
       description: 'Run once and exit',
       type: 'boolean',
       default: false
+    })
+    .config('opts', path => parse(
+      readFileSync(path).toString().match(/"[^"]*"|\S+/g).map(arg => {
+        return arg.replace(/^("|')(.*)(\1)$/, '$2');
+      })
+    ))
+    .option('opts', {
+      group: 'Options:',
+      description: 'Path to options file',
+      type: 'string',
+      default: 'bigtest/bigtest.opts'
     })
     .option('client.hostname', {
       group: 'Client Options:',


### PR DESCRIPTION
## Purpose

This reduces the amount of command line arguments needed to pass directly to the `bigtest run` command.

## Approach

`yargs` has a `config` option where we can load a custom configuration file. By default, it expects a `.json` file, but given a custom parse function we can parse the `.opts` file ourselves.

The parsing function splits the file contents by whitespace and strips quotes for individual arguments. It then passes this argv-like array to `yargs-parser` to give us an object of arguments to extend.

The `--opts` argument defaults to `bigtest/bigtest.opts` so if that file exists `bigtest run` will automatically load it's contents.

### Todo

- In the future, we could use a package like [findup](https://github.com/js-cli/node-findup-sync) to look upwards from the `bigtest` directory for a `bigtest.opts` file.