### PR TITLE
BigTest CLI init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ workflows:
             - install
       - test:
           requires:
+            - build
             - install
       # - deploy:
       #     requires:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+templates
+dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 #! /usr/bin/env node
 
+require('yargonaut')
+  .style('blue')
+  .helpStyle('green.bold')
+  .errorsStyle('red.bold');
+
 require('yargs')
   .scriptName('bigtest')
   .version(require('./package.json').version)

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -1,13 +1,83 @@
+import { copy, existsSync } from 'fs-extra';
+import { join } from 'path';
+import cleanupFiles from './utils/clean-up-files';
+
+const CWD = process.cwd();
+const BIGTEST_DIR = `${CWD}/bigtest`;
+let CLI_TEMPLATE_DIR = join(__dirname, '../../templates');
+let pathExists = path => existsSync(path);
+
+let copyNetwork = async framework => {
+  await copy(`${CLI_TEMPLATE_DIR}/network`, `${CWD}/bigtest/network`);
+  await copy(
+    `${CLI_TEMPLATE_DIR}/helpers/${framework}-network`,
+    `${CWD}/bigtest/helpers`
+  );
+
+  return true;
+};
+
+let copyWithFramework = async (framework, needsNetwork) => {
+  await copy(`${CLI_TEMPLATE_DIR}/bigtest`, `${CWD}/bigtest`);
+  await copy(
+    `${CLI_TEMPLATE_DIR}/helpers/${framework}`,
+    `${CWD}/bigtest/helpers`
+  );
+
+  if (needsNetwork) {
+    await copyNetwork(framework);
+  }
+
+  return { needsNetwork };
+};
+
 export function builder(yargs) {
-  yargs
-    .option('network', {
-      group: 'Options:',
-      description: 'Generate @bigtest/network files',
-      type: 'boolean',
-      default: false
-    });
+  yargs.option('network', {
+    group: 'Options:',
+    description:
+      'Generate @bigtest/mirage files for mocking the applications network',
+    type: 'boolean',
+    default: false
+  });
+
+  yargs.option('app-framework', {
+    group: 'Options:',
+    description: 'Generate the BigTest framework-specific test helper file',
+    type: 'string',
+    default: 'react'
+  });
 }
 
-export function handler(argv) {
-  console.log('init', argv);
+export async function handler(argv) {
+  let { network, appFramework } = argv;
+  let bigtestDirExists = pathExists(BIGTEST_DIR);
+  let networkDirExists = pathExists(`${BIGTEST_DIR}/network`);
+  let isCreatingNetwork = !networkDirExists && network;
+
+  if (bigtestDirExists && !isCreatingNetwork) {
+    console.info(`\nLooks like BigTest is already initialized\n`);
+
+    return;
+  }
+
+  if (bigtestDirExists && isCreatingNetwork) {
+    await copyNetwork(appFramework);
+
+    console.info('\n@bigtest/network has been initialized\n');
+
+    return;
+  }
+
+  try {
+    await copyWithFramework(appFramework, network).then(({ needsNetwork }) => {
+      let networkMessage = needsNetwork ? 'and @bigtest/mirage' : '';
+
+      console.info(
+        `\nBigTest has been initialized with @bigtest/${appFramework} ${networkMessage}\n`
+      );
+    });
+  } catch (error) {
+    console.log(`Initialize failed :( \n${error}`);
+    await cleanupFiles('bigtest', CWD);
+  }
 }

--- a/lib/init/utils/clean-up-files.js
+++ b/lib/init/utils/clean-up-files.js
@@ -1,0 +1,11 @@
+import { remove } from 'fs-extra';
+
+async function cleanupFiles(path, cwd) {
+  try {
+    await remove(`${cwd}/${path}`);
+  } catch (error) {
+    console.log(`Could not clean up files. ${error}`);
+  }
+}
+
+export default cleanupFiles;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "yarn build:cli && yarn build:assets",
     "build:cli": "babel --out-dir ./dist ./lib --verbose",
     "build:assets": "webpack --config webpack.config.js",
-    "lint": "eslint --ignore-path .gitignore ./",
+    "lint": "eslint ./",
     "postpublish": "bigtest-tag-version",
     "start": "nodemon --watch ./lib --exec 'yarn build'",
     "test": "mocha --opts ./tests/mocha.opts ./tests"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "rimraf": "^2.6.2",
     "ws": "^6.0.0",
     "x-default-browser": "^0.4.0",
+    "fs-extra": "^7.0.0",
+    "yargonaut": "^1.1.3",
     "yargs": "^12.0.1"
   },
   "devDependencies": {

--- a/templates/bigtest/bigtest.opts
+++ b/templates/bigtest/bigtest.opts
@@ -1,0 +1,3 @@
+--serve "yarn start"
+--serve-url "http://localhost:1234"
+--adapter mocha

--- a/templates/bigtest/index.js
+++ b/templates/bigtest/index.js
@@ -1,0 +1,5 @@
+// Since we use `async` / `await` we need babel-polyfill
+import 'babel-polyfill';
+
+// import your test files
+import './tests/app-test';

--- a/templates/bigtest/interactors/app.js
+++ b/templates/bigtest/interactors/app.js
@@ -1,0 +1,53 @@
+import {
+  interactor,
+  text,
+  fillable,
+  collection,
+  clickable,
+  triggerable,
+  property,
+  count
+} from '@bigtest/interactor';
+
+@interactor
+class TodoInteractor {
+  titleText = text('h1');
+  fillTodo = fillable('.new-todo');
+  todoCount = count('.todo-list li');
+  completedCount = count('.todo-list .completed');
+  todoCountText = text('.todo-count');
+  activeFilter = text('.filters .selected');
+  clickToggleAll = clickable('.toggle-all');
+  clickClearCompleted = clickable('.clear-completed');
+
+  submitTodo = triggerable('.new-todo', 'keydown', {
+    keyCode: 13
+  });
+
+  todoList = collection('.todo-list li', {
+    toggle: clickable('.toggle'),
+    delete: clickable('.destroy'),
+    todoText: text('label'),
+    isCompleted: property('.toggle', 'checked'),
+    doubleClick: triggerable('label', 'dblclick'),
+    fillInput: fillable('.edit'),
+    pressEnter: triggerable('.edit', 'keydown', {
+      keyCode: 13
+    })
+  });
+
+  clickFilter(filter) {
+    switch (filter) {
+      case 'All':
+        return this.$(`.filters li:first-child button`).click();
+      case 'Active':
+        return this.$(`.filters li:nth-child(2) button`).click();
+      case 'Complete':
+        return this.$(`.filters li:last-child button`).click();
+      default:
+        return false;
+    }
+  }
+}
+
+export default TodoInteractor;

--- a/templates/bigtest/interactors/app.js
+++ b/templates/bigtest/interactors/app.js
@@ -1,53 +1,8 @@
-import {
-  interactor,
-  text,
-  fillable,
-  collection,
-  clickable,
-  triggerable,
-  property,
-  count
-} from '@bigtest/interactor';
+import { interactor, isPresent } from '@bigtest/interactor';
 
 @interactor
-class TodoInteractor {
-  titleText = text('h1');
-  fillTodo = fillable('.new-todo');
-  todoCount = count('.todo-list li');
-  completedCount = count('.todo-list .completed');
-  todoCountText = text('.todo-count');
-  activeFilter = text('.filters .selected');
-  clickToggleAll = clickable('.toggle-all');
-  clickClearCompleted = clickable('.clear-completed');
-
-  submitTodo = triggerable('.new-todo', 'keydown', {
-    keyCode: 13
-  });
-
-  todoList = collection('.todo-list li', {
-    toggle: clickable('.toggle'),
-    delete: clickable('.destroy'),
-    todoText: text('label'),
-    isCompleted: property('.toggle', 'checked'),
-    doubleClick: triggerable('label', 'dblclick'),
-    fillInput: fillable('.edit'),
-    pressEnter: triggerable('.edit', 'keydown', {
-      keyCode: 13
-    })
-  });
-
-  clickFilter(filter) {
-    switch (filter) {
-      case 'All':
-        return this.$(`.filters li:first-child button`).click();
-      case 'Active':
-        return this.$(`.filters li:nth-child(2) button`).click();
-      case 'Complete':
-        return this.$(`.filters li:last-child button`).click();
-      default:
-        return false;
-    }
-  }
+class AppInteractor {
+  hasHeading = isPresent('h1');
 }
 
-export default TodoInteractor;
+export default AppInteractor;

--- a/templates/bigtest/tests/app-test.js
+++ b/templates/bigtest/tests/app-test.js
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { setupApplicationForTesting } from '../helpers/setup-app';
+import { when } from '@bigtest/convergence';
+
+import AppInteractor from '../interactors/app.js';
+
+describe('TodoMVC BigTest example', () => {
+  let TodoApp = new AppInteractor();
+
+  beforeEach(async () => {
+    await setupApplicationForTesting();
+  });
+
+  it('has ten todos to start with', () => {
+    expect(TodoApp.todoCount).to.equal(10);
+  });
+
+  describe('update BigTest install progress', () => {
+    beforeEach(async () => {
+      let completed = new Array(6).fill(null);
+
+      for (let index in completed) {
+        await TodoApp.todoList(parseInt(index, 10)).toggle();
+      }
+
+      await TodoApp.clickActiveFilter();
+    });
+
+    it('has four todos left', () => {
+      expect(TodoApp.todoCount).to.equal(4);
+    });
+
+    it('has the active filter selected', () => {
+      expect(TodoApp.activeFilter).to.equal('Active');
+    });
+
+    describe('adding the final todos with a typo', () => {
+      beforeEach(async () => {
+        await TodoApp.fillTodo('Fill in your interactor').submitTodo();
+        // Interactors are _super_ fast. Users can't add two todos in
+        // 20ms, so lets try to act like a user here and wait for a
+        // todo to be added before adding the next
+        await when(() => TodoApp.todoList().length === 5);
+        await TodoApp.fillTodo('rite tests').submitTodo();
+      });
+
+      it('increases the todo count', () => {
+        expect(TodoApp.todoCount).to.equal(6);
+      });
+
+      it('appends to the list', () => {
+        expect(TodoApp.todoList(4).todoText).to.equal(
+          'Fill in your interactor'
+        );
+        expect(TodoApp.todoList(5).todoText).to.equal('rite tests');
+      });
+
+      describe('fixing the typo', () => {
+        beforeEach(async () => {
+          await TodoApp.todoList(5)
+            .doubleClick()
+            .todoList(5)
+            .fillInput('Write tests')
+            .todoList(5)
+            .pressEnter();
+        });
+
+        it('properly edits the todo item', () => {
+          expect(TodoApp.todoList(5).todoText).to.equal('Write tests');
+        });
+
+        describe('viewing all Todos', () => {
+          beforeEach(async () => {
+            await TodoApp.clickAllFilter();
+          });
+
+          it('selects the right filter', () => {
+            expect(TodoApp.activeFilter).to.equal('All');
+          });
+
+          it('has the correct number of todos', () => {
+            expect(TodoApp.todoCount).to.equal(12);
+            expect(TodoApp.completedCount).to.equal(6);
+          });
+        });
+      });
+    });
+  });
+});

--- a/templates/bigtest/tests/app-test.js
+++ b/templates/bigtest/tests/app-test.js
@@ -1,90 +1,17 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { setupApplicationForTesting } from '../helpers/setup-app';
-import { when } from '@bigtest/convergence';
 
 import AppInteractor from '../interactors/app.js';
 
-describe('TodoMVC BigTest example', () => {
-  let TodoApp = new AppInteractor();
+describe('Your application', () => {
+  let App = new AppInteractor();
 
   beforeEach(async () => {
     await setupApplicationForTesting();
   });
 
-  it('has ten todos to start with', () => {
-    expect(TodoApp.todoCount).to.equal(10);
-  });
-
-  describe('update BigTest install progress', () => {
-    beforeEach(async () => {
-      let completed = new Array(6).fill(null);
-
-      for (let index in completed) {
-        await TodoApp.todoList(parseInt(index, 10)).toggle();
-      }
-
-      await TodoApp.clickActiveFilter();
-    });
-
-    it('has four todos left', () => {
-      expect(TodoApp.todoCount).to.equal(4);
-    });
-
-    it('has the active filter selected', () => {
-      expect(TodoApp.activeFilter).to.equal('Active');
-    });
-
-    describe('adding the final todos with a typo', () => {
-      beforeEach(async () => {
-        await TodoApp.fillTodo('Fill in your interactor').submitTodo();
-        // Interactors are _super_ fast. Users can't add two todos in
-        // 20ms, so lets try to act like a user here and wait for a
-        // todo to be added before adding the next
-        await when(() => TodoApp.todoList().length === 5);
-        await TodoApp.fillTodo('rite tests').submitTodo();
-      });
-
-      it('increases the todo count', () => {
-        expect(TodoApp.todoCount).to.equal(6);
-      });
-
-      it('appends to the list', () => {
-        expect(TodoApp.todoList(4).todoText).to.equal(
-          'Fill in your interactor'
-        );
-        expect(TodoApp.todoList(5).todoText).to.equal('rite tests');
-      });
-
-      describe('fixing the typo', () => {
-        beforeEach(async () => {
-          await TodoApp.todoList(5)
-            .doubleClick()
-            .todoList(5)
-            .fillInput('Write tests')
-            .todoList(5)
-            .pressEnter();
-        });
-
-        it('properly edits the todo item', () => {
-          expect(TodoApp.todoList(5).todoText).to.equal('Write tests');
-        });
-
-        describe('viewing all Todos', () => {
-          beforeEach(async () => {
-            await TodoApp.clickAllFilter();
-          });
-
-          it('selects the right filter', () => {
-            expect(TodoApp.activeFilter).to.equal('All');
-          });
-
-          it('has the correct number of todos', () => {
-            expect(TodoApp.todoCount).to.equal(12);
-            expect(TodoApp.completedCount).to.equal(6);
-          });
-        });
-      });
-    });
+  it('has an h1', () => {
+    expect(App.hasHeading).to.equal(true);
   });
 });

--- a/templates/helpers/react-network/setup-app.js
+++ b/templates/helpers/react-network/setup-app.js
@@ -1,0 +1,23 @@
+import { setupAppForTesting } from '@bigtest/react';
+import startMirage from '../network/start';
+
+// Import your applications root.
+// This is typically what you pass to `ReactDOM.render`
+// import App from '../../src/app.js';
+
+export async function setupApplicationForTesting() {
+  let server, app;
+
+  app = await setupAppForTesting(App, {
+    mountId: 'bigtesting-container',
+    setup: () => {
+      server = startMirage();
+      server.logging = false;
+    },
+    teardown: () => {
+      server.shutdown();
+    }
+  });
+
+  return { app, server };
+}

--- a/templates/helpers/react/setup-app.js
+++ b/templates/helpers/react/setup-app.js
@@ -1,0 +1,11 @@
+import { setupAppForTesting } from '@bigtest/react';
+
+// Import your applications root.
+// This is typically what you pass to `ReactDOM.render`
+// import App from '../../src/app.js';
+
+export async function setupApplicationForTesting() {
+  await setupAppForTesting(App, {
+    mountId: 'bigtesting-container'
+  });
+}

--- a/templates/network/config.js
+++ b/templates/network/config.js
@@ -1,0 +1,8 @@
+export default function configure() {
+  // this.urlPrefix = 'https://my.api.com';
+  // this.namespace = '/v1';
+  //
+  // this.get('/posts', ({ posts }, request) => {
+  //   return posts;
+  // });
+}

--- a/templates/network/factories/index.js
+++ b/templates/network/factories/index.js
@@ -1,0 +1,5 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as post } from './post';

--- a/templates/network/fixtures/index.js
+++ b/templates/network/fixtures/index.js
@@ -1,0 +1,5 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as post } from './post';

--- a/templates/network/force-fetch-polyfill.js
+++ b/templates/network/force-fetch-polyfill.js
@@ -1,0 +1,8 @@
+// This will force fetch to be polyfilled with XHR for pretender to
+// mock http requets.
+//
+// We do this inside of another imported file becuase it needs to happen
+// before the fetch is first imported. Imports are hoisted to the top so
+// settings this explicity before importing the app still won't work; it
+// needs to be inside another import that happens before the app import.
+window.fetch = undefined;

--- a/templates/network/index.js
+++ b/templates/network/index.js
@@ -1,0 +1,8 @@
+let start = () => {};
+
+// Make sure we don't include mirage in production
+if (process.env.NODE_ENV !== 'production') {
+  start = require('./start').default;
+}
+
+export default start;

--- a/templates/network/models/index.js
+++ b/templates/network/models/index.js
@@ -1,0 +1,5 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as post } from './post';

--- a/templates/network/scenarios/default.js
+++ b/templates/network/scenarios/default.js
@@ -1,0 +1,4 @@
+export default function defaultScenario(/* server */) {
+  // Create server data by default
+  // server.createList("post", 10);
+}

--- a/templates/network/scenarios/index.js
+++ b/templates/network/scenarios/index.js
@@ -1,0 +1,6 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as Post } from './post';
+export { default } from './default';

--- a/templates/network/serializers/index.js
+++ b/templates/network/serializers/index.js
@@ -1,0 +1,5 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as post } from './post';

--- a/templates/network/start.js
+++ b/templates/network/start.js
@@ -1,0 +1,41 @@
+import Mirage, { camelize } from '@bigtest/mirage';
+
+import baseConfig from './config';
+import './force-fetch-polyfill';
+
+import * as scenarios from './scenarios';
+import * as factories from './factories';
+// import * as fixtures from './fixtures';
+// import * as models from './models';
+// import * as serializers from './serializers';
+
+const environment = process.env.NODE_ENV;
+
+export default function startMirage(...scenarioNames) {
+  let server = new Mirage({
+    // Uncomment these imports if you add files
+    //
+    // factories,
+    // fixtures,
+    // models,
+    // serializers,
+    scenarios,
+    environment,
+    baseConfig
+  });
+
+  // mirage does not load our factories outside of testing when we do
+  // not declare a default scenario, so we load them ourselves
+  if (environment !== 'test') {
+    server.loadFactories(factories);
+  }
+
+  // mirage only loads a `default` scenario for us out of the box, so
+  // instead we run any scenarios after we initialize mirage
+  scenarioNames.filter(Boolean).forEach(scenarioName => {
+    let scenario = scenarios[camelize(scenarioName)];
+    if (scenario) scenario(server);
+  });
+
+  return server;
+}

--- a/tests/unit/init-test.js
+++ b/tests/unit/init-test.js
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import { promisify } from 'util';
+import { pathExists, readFile } from 'fs-extra';
+import { execFile } from 'child_process';
+import { describe, it, afterEach, beforeEach } from 'mocha';
+import cleanupFiles from '../../lib/init/utils/clean-up-files';
+
+const CWD = process.cwd();
+let exec = promisify(execFile);
+
+describe('bigtest init', () => {
+  describe('default init', function() {
+    let result;
+
+    beforeEach(async function() {
+      result = await exec('node', ['./index.js', 'init']);
+    });
+
+    afterEach(async () => {
+      await cleanupFiles('bigtest', CWD);
+    });
+
+    it('outputs the right message to the console', () => {
+      expect(result.stdout).to.equal(
+        '\nBigTest has been initialized with @bigtest/react \n\n'
+      );
+    });
+
+    it('creates a bigtest folder', async function() {
+      let hasBigtestFolder = await pathExists(`${CWD}/bigtest`);
+
+      expect(hasBigtestFolder).to.equal(true);
+    });
+
+    it('does not create a bigtest network folder', async function() {
+      let hasNetworkFolder = await pathExists(`${CWD}/bigtest/network`);
+
+      expect(hasNetworkFolder).to.equal(false);
+    });
+
+    it('inits with @bigtest/react', async function() {
+      let helperFile = await readFile(
+        `${CWD}/bigtest/helpers/setup-app.js`,
+        'utf-8'
+      );
+
+      expect(
+        helperFile.includes(
+          "import { setupAppForTesting } from '@bigtest/react';"
+        )
+      ).to.equal(true);
+    });
+  });
+
+  describe('bigtest init with network', function() {
+    let result;
+
+    beforeEach(async function() {
+      result = await exec('node', ['./index.js', 'init', '--network']);
+    });
+
+    afterEach(async () => {
+      await cleanupFiles('bigtest', CWD);
+    });
+
+    it('outputs the right message to the console', () => {
+      expect(result.stdout).to.equal(
+        '\nBigTest has been initialized with @bigtest/react and @bigtest/mirage\n\n'
+      );
+    });
+
+    it('creates a bigtest network folder', async function() {
+      let hasNetworkFolder = await pathExists(`${CWD}/bigtest/network`);
+
+      expect(hasNetworkFolder).to.equal(true);
+    });
+
+    it('inits @bigtest/react helper with @bigtest/mirage setup', async function() {
+      let helperFile = await readFile(
+        `${CWD}/bigtest/helpers/setup-app.js`,
+        'utf-8'
+      );
+
+      expect(
+        helperFile.includes(
+          "import { setupAppForTesting } from '@bigtest/react';"
+        )
+      ).to.equal(true);
+      expect(helperFile.includes('server = startMirage();')).to.equal(true);
+    });
+  });
+
+  describe('bigtest init with an existing directory', function() {
+    let result;
+
+    beforeEach(async function() {
+      await exec('node', ['./index.js', 'init']);
+    });
+
+    describe('without network', function() {
+      beforeEach(async function() {
+        result = await exec('node', ['./index.js', 'init']);
+      });
+
+      afterEach(async () => {
+        await cleanupFiles('bigtest', CWD);
+      });
+
+      it('outputs the right message to the console', () => {
+        expect(result.stdout).to.equal(
+          '\nLooks like BigTest is already initialized\n\n'
+        );
+      });
+    });
+
+    describe('with network', function() {
+      beforeEach(async function() {
+        result = await exec('node', ['./index.js', 'init', '--network']);
+      });
+
+      afterEach(async () => {
+        await cleanupFiles('bigtest', CWD);
+      });
+
+      it('outputs the right message to the console', () => {
+        expect(result.stdout).to.equal(
+          '\n@bigtest/network has been initialized\n\n'
+        );
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,7 +1311,7 @@ chai@^4.1.2:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chalk@^1.1.3:
+chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -2313,6 +2313,10 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
+figlet@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/figlet/-/figlet-1.2.0.tgz#6c46537378fab649146b5a6143dda019b430b410"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -2435,6 +2439,14 @@ from2@^2.1.0:
 from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+
+fs-extra@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -2574,7 +2586,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3205,6 +3217,12 @@ json-stable-stringify-without-jsonify@^1.0.1:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -3972,6 +3990,10 @@ param-case@2.1.x:
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
   dependencies:
     no-case "^2.2.0"
+
+parent-require@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parent-require/-/parent-require-1.0.0.tgz#746a167638083a860b0eef6732cb27ed46c32977"
 
 parse-asn1@^5.0.0:
   version "5.1.1"
@@ -5258,6 +5280,10 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -5559,6 +5585,14 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yargonaut@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/yargonaut/-/yargonaut-1.1.3.tgz#1cf6bbe511ecc865d6014203385628bcc39b0493"
+  dependencies:
+    chalk "^1.1.1"
+    figlet "^1.1.1"
+    parent-require "^1.0.0"
 
 yargs-parser@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
## What is this?

This implements the first `@bigtest/cli` command: `init`. `init` will scaffold the directories needed to get started with BigTest in your project. There are two arguments to the command:

- **`--network`** - When present the cli will generate the network directory and all of the appropriate sub-directories
- **`--app-framework`**  - Currently only supports the string `react`. In the future this will generate the proper BigTest application framework helpers you need to render your app. 

### TODOs

- [x] Learn how to test a CLI
- [x] Format logs to the CLI to look better
- [x] Have a working implementation out of the box for `@bigtest/mirage`
- [x] If `init` command fails, roll back any files that were created
- [x] Create TODO MVC app to run through tests 
- [x] Fill out example interactors
- [x] Fill out example tests

# Gif
![2018-08-11 16 15 32](https://user-images.githubusercontent.com/2072894/43996134-f3e8dc6a-9d81-11e8-96bf-b237756f11f2.gif)
