### PR TITLE
Fix opts config argument

### DIFF
--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -26,11 +26,20 @@ export function builder(yargs) {
       type: 'boolean',
       default: false
     })
-    .config('opts', path => parse(
-      readFileSync(path).toString().match(/"[^"]*"|\S+/g).map(arg => {
-        return arg.replace(/^("|')(.*)(\1)$/, '$2');
-      })
-    ))
+    .config('opts', path => {
+      try {
+        return parse(
+          readFileSync(path).toString()
+            .match(/"[^"]*"|\S+/g).map(arg => {
+              return arg.replace(/^("|')(.*)(\1)$/, '$2');
+            })
+        );
+      } catch (err) {
+        if (path !== 'bigtest/bigtest.opts') {
+          throw err;
+        }
+      }
+    })
     .option('opts', {
       group: 'Options:',
       description: 'Path to options file',


### PR DESCRIPTION
## Purpose

With the recent opts file addition (#5), the default argument for `--opts` is `bigtest/bigtest.opts` to autoload that file if present.

When that file is not present, the `config` callback throws an error. This is swallowed by the `fail` yargs handler which just exits the process.

## Approach

Wrap the handler in a try-catch block. If the provided path was the default path, ignore the error.

### TODO

- The yargs `fail` handler will still swallow any errors thrown from this portion of the code. There are some other areas where unhandled promise rejections cause node to complain. So overall, there will need to be a future PR to catch all unhandled errors.