### PR TITLE
State machines for `run`

### DIFF
--- a/lib/run/adapters/mocha.js
+++ b/lib/run/adapters/mocha.js
@@ -22,7 +22,7 @@ function serializeTest(test) {
     failing: test.state === 'failed',
     skipped: test.pending,
     duration: test.duration,
-    error: test.$error
+    errors: [test.$error].filter(Boolean)
   };
 }
 
@@ -33,16 +33,32 @@ function gatherTests(suite) {
   );
 }
 
-function formatError({ stack, message }) {
-  if (stack) {
-    // remove mocha stack entries
-    stack = stack.replace(/\n.+\/mocha\/mocha\.js\?\w*:[\d:]+\)?(?=(\n|$))/g, '');
-  }
+const mochaStackReg = /\n.+\/mocha\/mocha\.js\?\w*:[\d:]+\)?(?=(\n|$))/g;
 
-  return {
+function serializeError(err) {
+  let {
+    name,
     message,
     stack
-  };
+  } = err;
+
+  if (stack) {
+    // remove mocha stack entries
+    stack = stack.replace(mochaStackReg, '');
+
+    // remove message from beginning of stack
+    if (stack.includes(message)) {
+      stack = stack.replace(/^.*?\n/, '');
+    }
+
+    // remove indentation from stack
+    if (/^\s+/.test(stack)) {
+      stack = stack.replace(/^\s+/gm, '');
+    }
+  }
+
+  // formatted error
+  return { name, message, stack };
 }
 
 export default class MochaAdapter extends BaseAdapter {
@@ -79,8 +95,8 @@ export default class MochaAdapter extends BaseAdapter {
     this.send('test:end', serializeTest(test));
   }
 
-  handleFail(runnable, error) {
-    runnable.$error = formatError(error);
+  handleFail(runnable, err) {
+    runnable.$error = serializeError(err);
 
     if (runnable.type === 'hook') {
       this.handleTestEnd(runnable);

--- a/lib/run/adapters/mocha.js
+++ b/lib/run/adapters/mocha.js
@@ -88,18 +88,29 @@ export default class MochaAdapter extends BaseAdapter {
   }
 
   handleTest(test) {
-    this.send('test:start', serializeTest(test));
+    this.send('update', [{
+      ...serializeTest(test),
+      running: true
+    }]);
   }
 
   handleTestEnd(test) {
-    this.send('test:end', serializeTest(test));
+    this.send('update', [
+      serializeTest(test)
+    ]);
   }
 
   handleFail(runnable, err) {
     runnable.$error = serializeError(err);
+    let error = serializeError(err);
 
     if (runnable.type === 'hook') {
-      this.handleTestEnd(runnable);
+      error.message = `${runnable.originalTitle}: ${error.message}`;
+
+      this.send('update', gatherTests(runnable.parent).map(test => {
+        return { ...test, failing: true, errors: [error] };
+      }));
+    } else {
     }
   }
 

--- a/lib/run/client/main.js
+++ b/lib/run/client/main.js
@@ -3,10 +3,12 @@ import './styles.css';
 const { WebSocket } = window;
 
 class Client {
-  constructor({ hostname, port }) {
+  constructor({ hostname, port, search }) {
+    let [, id = ''] = search.match(/l=(\d{4})/) || [];
+
     this.listeners = {};
 
-    this.socket = new WebSocket(`ws://${hostname}:${port}/client`);
+    this.socket = new WebSocket(`ws://${hostname}:${port}/client/${id}`);
 
     this.socket.addEventListener('message', e => {
       try {

--- a/lib/run/coordinator.js
+++ b/lib/run/coordinator.js
@@ -120,17 +120,21 @@ export default class Coordinator {
     // once finished, maybe stop
     if (results.finished && this.once) {
       this.stop(results.status);
+
     // servers running & browsers connected
     } else if (results.started) {
       // just started, broadcast run to all connected adapters
       if (!state.started) {
         this.sockets.broadcast('adapter', 'run');
+
       // signal any newly waiting browsers to run
       } if (state.browsers !== results.browsers) {
         results.browsers.forEach((browser, b) => {
-          if (!state.browsers[b].waiting && browser.waiting) {
+          let prev = state.browsers[b];
+
+          if (!(prev && prev.waiting) && browser.waiting) {
             browser.sockets.forEach((socket, s) => {
-              if (!state.browsers[b].sockets[s]) {
+              if (!(prev && prev.sockets[s])) {
                 this.sockets.send(socket.id, 'run');
               }
             });

--- a/lib/run/coordinator.js
+++ b/lib/run/coordinator.js
@@ -165,8 +165,9 @@ export default class Coordinator {
   async launchBrowsers() {
     // launcher browsers
     await Promise.all(this.launchers.map(browser => {
+      let target = `${this.client.url}?l=${browser.id}`;
       this.log.info(`Launching ${browser.name}...`);
-      return browser.launch(this.client.url);
+      return browser.launch(target);
     }));
   }
 

--- a/lib/run/coordinator.js
+++ b/lib/run/coordinator.js
@@ -1,8 +1,15 @@
+import { when } from '@bigtest/convergence';
+
 import logger from './logger';
 import ClientServer from './client';
 import SocketServer from './sockets';
 import ProxyServer from './proxy';
 import ChildProcess from './process';
+
+import State, {
+  Store,
+  create
+} from './state';
 
 import {
   requireBrowser,
@@ -28,10 +35,14 @@ export default class Coordinator {
     ...options
   } = {}) {
     this.exit = exit;
+    this.once = once;
 
     // initialize logger and reporter
     this.log = logger({ name: 'BigTest', level: logLevel });
     this.reporter = new (requireReporter(reporter))();
+
+    // initialize state store
+    this.store = Store(create(State), this.handleUpdate.bind(this));
 
     // activate the adapter plugin
     if (options.adapter) {
@@ -86,25 +97,49 @@ export default class Coordinator {
 
     // client API
     this.sockets
-      .on('client/connect', (meta) => {
+      .on('client/connect', (meta, id) => {
+        if (id) this.store.updateLaunched(meta, id);
         this.sockets.send(meta.id, 'proxy:connected', this.proxy.url);
       });
 
     // Adapter API
     this.sockets
-      .on('adapter/connect', (meta) => {
-        this.sockets.send(meta.id, 'run');
-      })
-      .on('adapter/start', (meta) => {
-        this.reporter.handleStart(meta);
-      })
-      .on('adapter/test:end', (meta, test) => {
-        this.reporter.handleTestEnd(meta, test);
-      })
-      .on('adapter/end', (meta) => {
-        this.reporter.handleEnd(meta);
-        if (once) this.stop(this.reporter.status);
-      });
+      .on('adapter/connect', this.store.connectBrowser)
+      .on('adapter/disconnect', this.store.disconnectBrowser)
+      .on('adapter/start', this.store.startTests)
+      .on('adapter/update', this.store.updateTests)
+      .on('adapter/end', this.store.endTests);
+  }
+
+  handleUpdate(next, state, args) {
+    let results = next(state, args);
+
+    // let the reporter decide what to report
+    this.reporter.process(state, results);
+
+    // once finished, maybe stop
+    if (results.finished && this.once) {
+      this.stop(results.status);
+    // servers running & browsers connected
+    } else if (results.started) {
+      // just started, broadcast run to all connected adapters
+      if (!state.started) {
+        this.sockets.broadcast('adapter', 'run');
+      // signal any newly waiting browsers to run
+      } if (state.browsers !== results.browsers) {
+        results.browsers.forEach((browser, b) => {
+          if (!state.browsers[b].waiting && browser.waiting) {
+            browser.sockets.forEach((socket, s) => {
+              if (!state.browsers[b].sockets[s]) {
+                this.sockets.send(socket.id, 'run');
+              }
+            });
+          };
+        });
+      }
+    }
+
+    return results;
   }
 
   async start() {
@@ -113,8 +148,8 @@ export default class Coordinator {
       await this.startClient();
       await this.launchBrowsers();
 
-      // add new line between output and reporter
-      this.log.newLine();
+      // signal start to the state
+      this.store.start();
 
       // catch errors and cleanup
     } catch (err) {
@@ -167,8 +202,16 @@ export default class Coordinator {
     await Promise.all(this.launchers.map(browser => {
       let target = `${this.client.url}?l=${browser.id}`;
       this.log.info(`Launching ${browser.name}...`);
+      this.store.launchBrowser(browser.id);
       return browser.launch(target);
     }));
+
+    await when(() => {
+      if (!this.store.ready) {
+        // todo: what causes this?
+        throw Error('launched browsers did not connect');
+      };
+    }, 5000);
   }
 
   async stop(status = 0) {

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import { readFileSync } from 'fs';
 import parse from 'yargs-parser';
 
@@ -26,17 +27,17 @@ export function builder(yargs) {
       type: 'boolean',
       default: false
     })
-    .config('opts', path => {
+    .config('opts', filepath => {
       try {
         return parse(
-          readFileSync(path).toString()
+          readFileSync(filepath).toString()
             .match(/"[^"]*"|\S+/g).map(arg => {
               return arg.replace(/^("|')(.*)(\1)$/, '$2');
             })
         );
-      } catch (err) {
-        if (path !== 'bigtest/bigtest.opts') {
-          throw err;
+      } catch (error) {
+        if (filepath !== path.resolve('bigtest/bigtest.opts')) {
+          throw error;
         }
       }
     })

--- a/lib/run/reporters/base.js
+++ b/lib/run/reporters/base.js
@@ -17,11 +17,31 @@ export default class Reporter {
     return this.write('\n');
   }
 
-  indent(n) {
-    return this.write(''.padStart(n, ' '));
+  indent(n, str = '') {
+    return this.write(
+      str.replace(/^[\t ]*/gm, () => ''.padStart(n, ' '))
+    );
   }
 
-  handleStart() {}
-  handleTestEnd() {}
-  handleEnd() {}
+  process(prev, next) {
+    // tests started
+    if (!prev.started && next.started) {
+      this.onStart(next.tests);
+    // tests finished
+    } else if (!prev.finished && next.finished) {
+      this.onEnd(next.tests);
+    // tests added or updated
+    } else if (prev.tests !== next.tests) {
+      // check for test updates
+      next.tests.forEach((nextTest, i) => {
+        if (prev.tests[i] !== nextTest) {
+          this.onUpdate(nextTest);
+        }
+      });
+    }
+  }
+
+  onStart() {}
+  onUpdate() {}
+  onEnd() {}
 }

--- a/lib/run/reporters/dot.js
+++ b/lib/run/reporters/dot.js
@@ -2,34 +2,27 @@ import chalk from 'chalk';
 import BaseReporter from './base';
 
 export default class DotReporter extends BaseReporter {
-  tests = [];
-
-  handleStart(meta, test) {
-    if (this.tests.length) {
-      this.newLine();
-    }
-
-    this.tests = [];
-    this.status = 0;
+  onStart() {
+    this.newLine();
   }
 
-  handleTestEnd(meta, test) {
-    if (test.passing) {
-      this.write(chalk.green('.'));
-    } else if (test.failing) {
-      this.write(chalk.red('F'));
-    } else if (test.skipped) {
-      this.write(chalk.white(','));
+  onUpdate(test) {
+    if (test.finished) {
+      if (test.passing) {
+        this.write(chalk.green('.'));
+      } else if (test.failing) {
+        this.write(chalk.red('F'));
+      } else if (test.skipped) {
+        this.write(chalk.white(','));
+      }
     }
-
-    this.tests.push(test);
   }
 
-  handleEnd(meta) {
-    let passing = this.tests.filter(t => t.passing);
-    let failing = this.tests.filter(t => t.failing);
-    let skipped = this.tests.filter(t => t.skipped);
-    let duration = this.tests.reduce((d, t) => d + t.duration, 0);
+  onEnd(tests) {
+    let passing = tests.filter(t => t.passing);
+    let failing = tests.filter(t => t.failing);
+    let skipped = tests.filter(t => t.skipped);
+    let duration = tests.reduce((d, t) => d + t.duration, 0);
 
     this.newLine().newLine()
       .log(chalk`{green ${passing.length} passing} {gray ${duration}ms}`);
@@ -43,19 +36,39 @@ export default class DotReporter extends BaseReporter {
     }
 
     if (failing.length) {
-      this.status = 1;
-
       this.newLine()
         .log(chalk.white.bold.underline(`FAILED TESTS:`));
 
-      for (let i in failing) {
-        let fail = failing[i];
+      let current, depth;
+      let printpath = paths => {
+        paths.forEach((path, i) => {
+          depth = 2 * i;
 
-        this.newLine()
-          .indent(2).log(chalk.white(`${i}) ${fail.name}`))
-          .indent(2).log(chalk.red(fail.error.message))
-          .indent(2).log(chalk.gray(fail.error.stack));
-      }
+          if (!current || current[i] !== path) {
+            this.indent(depth).log(path);
+          }
+
+          depth += 2;
+        });
+
+        current = paths;
+      };
+
+      failing.forEach((fail, i) => {
+        this.newLine();
+        printpath(fail.path);
+
+        this.indent(depth)
+          .log(chalk.white.bold(`${i + 1}) ${fail.name}`));
+
+        fail.errors.forEach(error => {
+          this.newLine()
+            .indent(depth).log(chalk.red(`${error.name}: ${error.message}`))
+            .indent(depth + 2, chalk.gray(error.stack)).newLine();
+        });
+      });
     }
+
+    this.newLine();
   }
 }

--- a/lib/run/reporters/dot.js
+++ b/lib/run/reporters/dot.js
@@ -62,9 +62,18 @@ export default class DotReporter extends BaseReporter {
           .log(chalk.white.bold(`${i + 1}) ${fail.name}`));
 
         fail.errors.forEach(error => {
-          this.newLine()
-            .indent(depth).log(chalk.red(`${error.name}: ${error.message}`))
-            .indent(depth + 2, chalk.gray(error.stack)).newLine();
+          this.newLine();
+
+          if (fail.all.length > 1) {
+            this.indent(depth).log(chalk.gray(error.browser));
+          }
+
+          this.indent(depth)
+            .log(chalk.red(`${error.name}: ${error.message}`));
+
+          if (error.stack) {
+            this.indent(depth + 2, chalk.gray(error.stack)).newLine();
+          }
         });
       });
     }

--- a/lib/run/sockets.js
+++ b/lib/run/sockets.js
@@ -92,7 +92,7 @@ export default class SocketServer extends EventEmitter {
    * @param {Request} request - WebSocket request object
    */
   handleConnection(socket, request) {
-    let path = url.parse(request.url).pathname.substr(1);
+    let [path, id] = url.parse(request.url).pathname.substr(1).split('/');
     let browser = parseBrowserName(request.headers['user-agent']);
     let meta = { id: uid(), browser, path };
 
@@ -100,7 +100,7 @@ export default class SocketServer extends EventEmitter {
     socket.on('message', this.handleMessage.bind(this, socket));
 
     this.meta.set(socket, meta);
-    this.emit(`${path}/connect`, meta);
+    this.emit(`${path}/connect`, meta, id);
   }
 
   /**

--- a/lib/run/state/browser.js
+++ b/lib/run/state/browser.js
@@ -1,0 +1,117 @@
+import create, { update } from './create';
+
+export class BrowserSocket {
+  id = null;
+
+  get waiting() {
+    return !(this.running || this.finished);
+  }
+
+  run() {
+    if (!this.running) {
+      return create(RunningBrowserSocket, this);
+    } else {
+      return this;
+    }
+  }
+}
+
+export class RunningBrowserSocket extends BrowserSocket {
+  running = true;
+
+  done() {
+    return create(FinishedBrowserSocket, this);
+  }
+}
+
+export class FinishedBrowserSocket extends BrowserSocket {
+  finished = true;
+}
+
+export default class Browser {
+  id = null;
+  name = 'Unkown';
+  launched = false;
+  sockets = [];
+
+  get connected() {
+    return this.sockets.length > 0;
+  }
+
+  get waiting() {
+    return this.connected &&
+      this.sockets.some(socket => socket.waiting);
+  }
+
+  get running() {
+    return this.connected &&
+      this.sockets.some(socket => socket.running);
+  }
+
+  get finished() {
+    return this.connected &&
+      this.sockets.every(socket => socket.finished);
+  }
+
+  connect(sid) {
+    let index = this.sockets.findIndex(socket => {
+      return socket.id === sid;
+    });
+
+    if (index === -1) {
+      return this.set({
+        sockets: this.sockets.concat(
+          create(BrowserSocket, { id: sid })
+        )
+      });
+    } else {
+      return this;
+    }
+  }
+
+  disconnect(sid) {
+    let index = this.sockets.findIndex(socket => {
+      return socket.id === sid;
+    });
+
+    if (index > -1) {
+      return this.set({
+        sockets: update(this.sockets, index, null)
+      });
+    } else {
+      return this;
+    }
+  }
+
+  run(sid) {
+    let index = this.sockets.findIndex(socket => {
+      return socket.id === sid;
+    });
+
+    if (index > -1) {
+      return this.set({
+        sockets: update(this.sockets, index, socket => {
+          return socket.run();
+        })
+      });
+    } else {
+      return this;
+    }
+  }
+
+  done(sid) {
+    let index = this.sockets.findIndex(socket => {
+      return socket.id === sid;
+    });
+
+    if (index > -1) {
+      return this.set({
+        sockets: update(this.sockets, index, socket => {
+          return socket.done();
+        })
+      });
+    } else {
+      return this;
+    }
+  }
+}

--- a/lib/run/state/create.js
+++ b/lib/run/state/create.js
@@ -1,0 +1,43 @@
+const { assign } = Object;
+
+const hasOwnProperty = (obj, prop) => {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+};
+
+export default function create(Type, props = {}) {
+  let instance = new (class extends Type {
+    set(props) {
+      let extended = assign({}, this, props);
+      return create(this.constructor, extended);
+    }
+  })();
+
+  for (let key in instance) {
+    if (props[key] != null) {
+      instance[key] = props[key];
+    }
+  }
+
+  if (hasOwnProperty(Type.prototype, 'initialize')) {
+    instance = instance.initialize(props) || instance;
+  }
+
+  return instance;
+}
+
+export function update(array, index, fn) {
+  if (index === -1) index = array.length;
+
+  let item = array[index];
+  let updated = fn && fn(item);
+
+  if (item && !updated) {
+    return array.slice(0, index)
+      .concat(array.slice(index + 1));
+  } else if (updated !== item) {
+    return array.slice(0, index)
+      .concat(updated, array.slice(index + 1));
+  } else {
+    return array;
+  }
+}

--- a/lib/run/state/index.js
+++ b/lib/run/state/index.js
@@ -1,0 +1,143 @@
+import create, { update } from './create';
+import Browser from './browser';
+import Test from './test';
+
+export { default as Store } from './store';
+export { create };
+
+export default class State {
+  tests = [];
+  browsers = [];
+  started = false;
+
+  get ready() {
+    return this.browsers
+      .filter(browser => browser.launched)
+      .every(browser => browser.connected);
+  }
+
+  get finished() {
+    return this.browsers
+      .filter(browser => browser.launched)
+      .every(browser => browser.finished);
+  }
+
+  get status() {
+    return this.tests.some(test => test.failing) ? 1 : 0;
+  }
+
+  start() {
+    if (!this.started) {
+      return this.set({ started: true });
+    } else {
+      return this;
+    }
+  }
+
+  launchBrowser(id) {
+    return this.set({
+      browsers: this.browsers.concat(
+        create(Browser, { id, launched: true })
+      )
+    });
+  }
+
+  updateLaunched(meta, id) {
+    let index = this.browsers.findIndex(browser => {
+      return browser.launched && browser.id === id;
+    });
+
+    if (index > -1) {
+      return this.set({
+        browsers: update(this.browsers, index, browser => {
+          return browser.set({ name: meta.browser });
+        })
+      });
+    } else {
+      return this;
+    }
+  }
+
+  connectBrowser(meta) {
+    let index = this.browsers.findIndex(browser => {
+      return browser.name === meta.browser;
+    });
+
+    return this.set({
+      browsers: update(this.browsers, index, browser => {
+        if (!browser) {
+          browser = create(Browser, { name: meta.browser });
+        }
+
+        return browser.connect(meta.id);
+      })
+    });
+  }
+
+  disconnectBrowser(meta) {
+    let index = this.browsers.findIndex(browser => {
+      return browser.name === meta.browser;
+    });
+
+    if (index > -1) {
+      return this.set({
+        browsers: update(this.browsers, index, browser => {
+          return browser.disconnect(meta.id);
+        })
+      });
+    } else {
+      return this;
+    }
+  }
+
+  startTests(meta, tests) {
+    let index = this.browsers.findIndex(browser => {
+      return browser.name === meta.browser;
+    });
+
+    if (index > -1) {
+      let running = this.set({
+        browsers: update(this.browsers, index, browser => {
+          return browser.run(meta.id);
+        })
+      });
+
+      return running.updateTests(meta, tests);
+    } else {
+      return this;
+    }
+  }
+
+  updateTests(meta, tests) {
+    return this.set({
+      tests: tests.reduce((tests, test) => {
+        let props = { browser: meta.browser, ...test };
+
+        let index = this.tests.findIndex(test => {
+          return test.name === props.name &&
+            test.path.every((p, i) => p === props.path[i]);
+        });
+
+        return update(tests, index, test => {
+          return test ? test.update(props) : create(Test, props);
+        });
+      }, this.tests)
+    });
+  }
+
+  endTests(meta) {
+    let index = this.browsers.findIndex(browser => {
+      return browser.name === meta.browser;
+    });
+
+    if (index > -1) {
+      return this.set({
+        browsers: update(this.browsers, index, browser => {
+          return browser.done(meta.id);
+        })
+      });
+    } else {
+      return this;
+    }
+  }
+}

--- a/lib/run/state/index.js
+++ b/lib/run/state/index.js
@@ -17,9 +17,7 @@ export default class State {
   }
 
   get finished() {
-    return this.browsers
-      .filter(browser => browser.launched)
-      .every(browser => browser.finished);
+    return this.browsers.every(browser => browser.finished);
   }
 
   get status() {

--- a/lib/run/state/store.js
+++ b/lib/run/state/store.js
@@ -1,0 +1,67 @@
+const {
+  assign,
+  defineProperties,
+  entries,
+  getOwnPropertyDescriptors,
+  getPrototypeOf,
+  keys
+} = Object;
+
+function getPropertyDescriptors(obj) {
+  let proto = getPrototypeOf(obj);
+  let descriptors = {};
+
+  while (proto && proto !== Object.prototype) {
+    descriptors = assign({}, getOwnPropertyDescriptors(proto), descriptors);
+    proto = getPrototypeOf(proto);
+  }
+
+  return descriptors;
+}
+
+export default function Store(state, middle) {
+  let store = new (class Store {
+    get state() { return state; }
+  })();
+
+  let wrap = fn => (...args) => {
+    let next = (s, a) => fn.apply(s, a);
+
+    if (middle) {
+      state = middle(next, state, args);
+    } else {
+      state = next(state, args);
+    }
+
+    return store;
+  };
+
+  let descriptors = entries(getPropertyDescriptors(state))
+    .reduce((descriptors, [key, prop]) => {
+      // methods
+      if (typeof prop.value === 'function' &&
+          key !== 'constructor' && key !== 'set') {
+        return assign(descriptors, {
+          [key]: { value: wrap(prop.value) }
+        });
+      // getters
+      } else if (typeof prop.get === 'function' && key !== 'state') {
+        return assign(descriptors, {
+          [key]: { get: () => state[key] }
+        });
+      } else {
+        return descriptors;
+      }
+    }, keys(state).reduce((descriptors, key) => {
+      // enumerable properties
+      if (key !== 'state') {
+        return assign(descriptors, {
+          [key]: { get: () => state[key] }
+        });
+      } else {
+        return descriptors;
+      }
+    }, {}));
+
+  return defineProperties(store, descriptors);
+}

--- a/lib/run/state/test.js
+++ b/lib/run/state/test.js
@@ -50,13 +50,35 @@ export class PassingBrowserTest extends BrowserTest {
   passing = true;
 }
 
+export class SkippedBrowserTest extends BrowserTest {
+  skipped = true;
+}
+
 export class FailingBrowserTest extends BrowserTest {
   failing = true;
   errors = [];
+
+  initialize(props) {
+    if (props.errors && props.errors.length) {
+      return this.set({
+        errors: props.errors.map(err => {
+          return create(BrowserError, {
+            browser: this.browser,
+            ...err
+          });
+        })
+      });
+    } else {
+      return this;
+    }
+  }
 }
 
-export class SkippedBrowserTest extends BrowserTest {
-  skipped = true;
+export class BrowserError {
+  name = 'Error';
+  message = 'unknown error';
+  browser = 'Unkown';
+  stack = null;
 }
 
 export default class Test {

--- a/lib/run/state/test.js
+++ b/lib/run/state/test.js
@@ -1,0 +1,122 @@
+import create, { update } from './create';
+
+export class BrowserTest {
+  browser = 'Unkown';
+  duration = 0;
+
+  initialize(props) {
+    return this.update(props);
+  }
+
+  update(props) {
+    if (!this.running && props.running) {
+      return create(RunningBrowserTest, props);
+    } else if (!this.passing && props.passing) {
+      return create(PassingBrowserTest, props);
+    } else if (!this.failing && props.failing) {
+      return create(FailingBrowserTest, props);
+    } else if (!this.skipped && props.skipped) {
+      return create(SkippedBrowserTest, props);
+    } else if (!this.pending) {
+      return create(BrowserTest, props);
+    } else {
+      return this;
+    }
+  }
+
+  get pending() {
+    return !(
+      this.running ||
+        this.passing ||
+        this.failing ||
+        this.skipped
+    );
+  }
+
+  get finished() {
+    return !this.running && (
+      this.passing ||
+        this.failing ||
+        this.skipped
+    );
+  }
+}
+
+export class RunningBrowserTest extends BrowserTest {
+  running = true;
+}
+
+export class PassingBrowserTest extends BrowserTest {
+  passing = true;
+}
+
+export class FailingBrowserTest extends BrowserTest {
+  failing = true;
+  errors = [];
+}
+
+export class SkippedBrowserTest extends BrowserTest {
+  skipped = true;
+}
+
+export default class Test {
+  name = '';
+  path = [];
+  all = [];
+
+  get duration() {
+    return this.all.reduce((duration, test) => {
+      return Math.max(duration, test.duration);
+    }, 0);
+  }
+
+  get pending() {
+    return this.all.every(test => test.pending);
+  }
+
+  get finished() {
+    return this.all.every(test => test.finished);
+  }
+
+  get running() {
+    return this.all.some(test => test.running);
+  }
+
+  get passing() {
+    return this.all.every(test => test.passing);
+  }
+
+  get failing() {
+    return this.all.some(test => test.failing);
+  }
+
+  get skipped() {
+    return this.all.every(test => test.skipped);
+  }
+
+  get errors() {
+    return this.all.reduce((errors, test) => {
+      return test.failing ? errors.concat(test.errors) : errors;
+    }, []);
+  }
+
+  initialize(props) {
+    if (props.browser) {
+      return this.update(props);
+    } else {
+      return this;
+    }
+  }
+
+  update(props) {
+    let index = this.all.findIndex(test => {
+      return test.browser === props.browser;
+    });
+
+    return this.set({
+      all: update(this.all, index, test => {
+        return test ? test.update(props) : create(BrowserTest, props);
+      })
+    });
+  }
+}


### PR DESCRIPTION
## Purpose

Adding some proper state opens a whole lot for the `bigtest run` command. The main benefit being better multi-browser support! 

Before, when a new browser started its tests it would overwrite the simple state within the reporter. When two browsers did this at the same time, it caused some funky stuff. For example, when one browser reports a hook failure and the other does not, a separate test is created with the hook name added to the original test's name. This caused some passing / failing tests to hang around.

With the `--once` option, it would only wait for the first browser to finish and exit with the status of the reporter, which could get into aforementioned funky states. Now, we can wait for all connected browsers to be finished before exiting.

Similarly, we can wait for launched browsers to connect before starting any tests. Before, tests were started immediately when the browser connected. If a browser was slower than another to open, the reporter might already start printing results of the first browser before the other has a chance to connect.

## Approach

The "simple" state machines in the `state` directory are written based on two premises: 1) only the properties defined on a class are kept in memory, and 2) transitions should be immutable. Using the `create` function enforces 1, and adds a `set` method to assist with 2.

The `store` helper creates a new `Store` class with a computed `state` that is updated when transitions are invoked through the store. Other properties defined on the provided state instance are mapped to store getters as well. 

The adapter socket API was simplified to three events: `start`, `update`, and `end`. Each takes an array of tests and updates specific browser tests within the state. The `start` and `end` events also trigger transitions to signal when a browser is running or done running tests.

When the state updates, the coordinator processes the previous and next states to determine when it should stop (if `--once` is provided), if testing has started (to kickoff initial browsers), and if it needs to signal newly connected browsers to run tests.

The coordinator also gives the reporter its own opportunity to process the previous and next states. The reporter then triggers `onStart`, `onUpdate`, or `onEnd`. The difference from the similarly-named adapter socket events is `onUpdate` is called with only a single updated test instead of an array of tests.

The new state allows the reporter to handle and output tests much more elegantly (including which browser the error came from):

![sample reporter output](https://user-images.githubusercontent.com/5005153/44379009-93366f00-a4c9-11e8-9cff-ec2305275d82.png)


### Todo

- Tests 😐