### PR TITLE
Update readme for `run` changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,28 @@ entry: isTesting ? glob.sync('tests/*-test.js') : 'src/index.js',
 // point to an index file where you import each test
 ```
 
-2. Tell BigTest how to serve your app (`--serve-url` defaults to
+2. Tell BigTest how to serve your app (`--serve.url` defaults to
 `http://localhost:3000`) and specify an adapter to use (`mocha` is
 currently the only supported adapter).
 ``` bash
 $ bigtest run \
   --serve "yarn webpack-serve" \
-  --serve-url "http://localhost:8080" \
+  --serve.url "http://localhost:8080" \
   --adapter mocha
+```
+
+2 **Alt**: BigTest can also accept an `.opts` file, which it will look for
+by default at `bigtest/bitest.opts`.
+
+``` bash
+# bigtest/bigtest.opts
+--serve "yarn webpack-serve"
+--serve.url "http://localhost:8080"
+--adapter mocha
+```
+
+``` bash
+$ bigtest run
+# OR
+$ bigtest run --opts path/to/file.opts
 ```


### PR DESCRIPTION
## Purpose

`--serve-url` recently became `--serve.url` and the `run` command now accepts an `.opts` file.

## Approach

Changed the `--serve-url` argument and added a section for the `.opts` file.