### PR TITLE
bigtest init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ workflows:
             - install
       - test:
           requires:
+            - build
             - install
       # - deploy:
       #     requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,6 @@ workflows:
             - install
       - test:
           requires:
-            - build
             - install
       # - deploy:
       #     requires:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+templates
+dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -1,36 +1,10 @@
-import { copy, existsSync } from 'fs-extra';
-import { join } from 'path';
+import { existsSync } from 'fs-extra';
 import chalk from 'chalk';
 import cleanupFiles from './utils/clean-up-files';
+import { copyNetwork, copyWithFramework } from './utils/copy-with';
 
 const CWD = process.cwd();
 const BIGTEST_DIR = `${CWD}/bigtest`;
-let CLI_TEMPLATE_DIR = join(__dirname, '../../templates');
-let pathExists = path => existsSync(path);
-
-let copyNetwork = async framework => {
-  await copy(`${CLI_TEMPLATE_DIR}/network`, `${CWD}/bigtest/network`);
-  await copy(
-    `${CLI_TEMPLATE_DIR}/helpers/${framework}-network`,
-    `${CWD}/bigtest/helpers`
-  );
-
-  return true;
-};
-
-let copyWithFramework = async (framework, needsNetwork) => {
-  await copy(`${CLI_TEMPLATE_DIR}/bigtest`, `${CWD}/bigtest`);
-  await copy(
-    `${CLI_TEMPLATE_DIR}/helpers/${framework}`,
-    `${CWD}/bigtest/helpers`
-  );
-
-  if (needsNetwork) {
-    await copyNetwork(framework);
-  }
-
-  return { needsNetwork };
-};
 
 function builder(yargs) {
   yargs
@@ -52,8 +26,8 @@ function builder(yargs) {
 
 async function handler(argv) {
   let { network, appFramework } = argv;
-  let bigtestDirExists = pathExists(BIGTEST_DIR);
-  let networkDirExists = pathExists(`${BIGTEST_DIR}/network`);
+  let bigtestDirExists = existsSync(BIGTEST_DIR);
+  let networkDirExists = existsSync(`${BIGTEST_DIR}/network`);
   let isCreatingNetwork = !networkDirExists && network;
 
   if (bigtestDirExists && !isCreatingNetwork) {
@@ -63,7 +37,7 @@ async function handler(argv) {
   }
 
   if (bigtestDirExists && isCreatingNetwork) {
-    await copyNetwork(appFramework);
+    await copyNetwork(CWD, appFramework);
 
     console.info('\n@bigtest/network has been initialized\n');
 
@@ -71,13 +45,15 @@ async function handler(argv) {
   }
 
   try {
-    await copyWithFramework(appFramework, network).then(({ needsNetwork }) => {
-      let networkMessage = needsNetwork ? 'and @bigtest/mirage' : '';
+    await copyWithFramework(CWD, appFramework, network).then(
+      ({ needsNetwork }) => {
+        let networkMessage = needsNetwork ? 'and @bigtest/mirage' : '';
 
-      console.info(
-        `\nBigTest has been initialized with @bigtest/${appFramework} ${networkMessage}\n`
-      );
-    });
+        console.info(
+          `\nBigTest has been initialized with @bigtest/${appFramework} ${networkMessage}\n`
+        );
+      }
+    );
   } catch (error) {
     console.log(`Initialize failed :( \n${error}`);
     await cleanupFiles('bigtest', CWD);

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -1,13 +1,83 @@
+import { copy, existsSync } from 'fs-extra';
+import { join } from 'path';
+import cleanupFiles from './utils/clean-up-files';
+
+const CWD = process.cwd();
+const BIGTEST_DIR = `${CWD}/bigtest`;
+let CLI_TEMPLATE_DIR = join(__dirname, '../../templates');
+let pathExists = path => existsSync(path);
+
+let copyNetwork = async framework => {
+  await copy(`${CLI_TEMPLATE_DIR}/network`, `${CWD}/bigtest/network`);
+  await copy(
+    `${CLI_TEMPLATE_DIR}/helpers/${framework}-network`,
+    `${CWD}/bigtest/helpers`
+  );
+
+  return true;
+};
+
+let copyWithFramework = async (framework, needsNetwork) => {
+  await copy(`${CLI_TEMPLATE_DIR}/bigtest`, `${CWD}/bigtest`);
+  await copy(
+    `${CLI_TEMPLATE_DIR}/helpers/${framework}`,
+    `${CWD}/bigtest/helpers`
+  );
+
+  if (needsNetwork) {
+    await copyNetwork(framework);
+  }
+
+  return { needsNetwork };
+};
+
 export function builder(yargs) {
-  yargs
-    .option('network', {
-      group: 'Options:',
-      description: 'Generate @bigtest/network files',
-      type: 'boolean',
-      default: false
-    });
+  yargs.option('network', {
+    group: 'Options:',
+    description:
+      'Generate @bigtest/mirage files for mocking the applications network',
+    type: 'boolean',
+    default: false
+  });
+
+  yargs.option('app-framework', {
+    group: 'Options:',
+    description: 'Generate the BigTest framework-specific test helper file',
+    type: 'string',
+    default: 'react'
+  });
 }
 
-export function handler(argv) {
-  console.log('init', argv);
+export async function handler(argv) {
+  let { network, appFramework } = argv;
+  let bigtestDirExists = pathExists(BIGTEST_DIR);
+  let networkDirExists = pathExists(`${BIGTEST_DIR}/network`);
+  let isCreatingNetwork = !networkDirExists && network;
+
+  if (bigtestDirExists && !isCreatingNetwork) {
+    console.info(`\nLooks like BigTest is already initialized\n`);
+
+    return;
+  }
+
+  if (bigtestDirExists && isCreatingNetwork) {
+    await copyNetwork(appFramework);
+
+    console.info('\n@bigtest/network has been initialized\n');
+
+    return;
+  }
+
+  try {
+    await copyWithFramework(appFramework, network).then(({ needsNetwork }) => {
+      let networkMessage = needsNetwork ? 'and @bigtest/mirage' : '';
+
+      console.info(
+        `\nBigTest has been initialized with @bigtest/${appFramework} ${networkMessage}\n`
+      );
+    });
+  } catch (error) {
+    console.log(`Initialize failed :( \n${error}`);
+    await cleanupFiles('bigtest', CWD);
+  }
 }

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -1,10 +1,4 @@
-import { existsSync } from 'fs-extra';
 import chalk from 'chalk';
-import cleanupFiles from './utils/clean-up-files';
-import { copyNetwork, copyWithFramework } from './utils/copy-with';
-
-const CWD = process.cwd();
-const BIGTEST_DIR = `${CWD}/bigtest`;
 
 function builder(yargs) {
   yargs
@@ -25,39 +19,7 @@ function builder(yargs) {
 }
 
 async function handler(argv) {
-  let { network, appFramework } = argv;
-  let bigtestDirExists = existsSync(BIGTEST_DIR);
-  let networkDirExists = existsSync(`${BIGTEST_DIR}/network`);
-  let isCreatingNetwork = !networkDirExists && network;
-
-  if (bigtestDirExists && !isCreatingNetwork) {
-    console.info(`\nLooks like BigTest is already initialized\n`);
-
-    return;
-  }
-
-  if (bigtestDirExists && isCreatingNetwork) {
-    await copyNetwork(CWD, appFramework);
-
-    console.info('\n@bigtest/network has been initialized\n');
-
-    return;
-  }
-
-  try {
-    await copyWithFramework(CWD, appFramework, network).then(
-      ({ needsNetwork }) => {
-        let networkMessage = needsNetwork ? 'and @bigtest/mirage' : '';
-
-        console.info(
-          `\nBigTest has been initialized with @bigtest/${appFramework} ${networkMessage}\n`
-        );
-      }
-    );
-  } catch (error) {
-    console.log(`Initialize failed :( \n${error}`);
-    await cleanupFiles('bigtest', CWD);
-  }
+  await require('./init').default(argv);
 }
 
 module.exports = {

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -1,5 +1,6 @@
 import { copy, existsSync } from 'fs-extra';
 import { join } from 'path';
+import chalk from 'chalk';
 import cleanupFiles from './utils/clean-up-files';
 
 const CWD = process.cwd();
@@ -31,24 +32,25 @@ let copyWithFramework = async (framework, needsNetwork) => {
   return { needsNetwork };
 };
 
-export function builder(yargs) {
-  yargs.option('network', {
-    group: 'Options:',
-    description:
-      'Generate @bigtest/mirage files for mocking the applications network',
-    type: 'boolean',
-    default: false
-  });
-
-  yargs.option('app-framework', {
-    group: 'Options:',
-    description: 'Generate the BigTest framework-specific test helper file',
-    type: 'string',
-    default: 'react'
-  });
+function builder(yargs) {
+  yargs
+    .usage(chalk`{green.bold Usage:} $0 run [options]`)
+    .option('network', {
+      group: 'Options:',
+      description:
+        'Generate @bigtest/mirage files for mocking the applications network',
+      type: 'boolean',
+      default: false
+    })
+    .option('app-framework', {
+      group: 'Options:',
+      description: 'Generate the BigTest framework-specific test helper file',
+      type: 'string',
+      default: 'react'
+    });
 }
 
-export async function handler(argv) {
+async function handler(argv) {
   let { network, appFramework } = argv;
   let bigtestDirExists = pathExists(BIGTEST_DIR);
   let networkDirExists = pathExists(`${BIGTEST_DIR}/network`);
@@ -81,3 +83,9 @@ export async function handler(argv) {
     await cleanupFiles('bigtest', CWD);
   }
 }
+
+module.exports = {
+  command: 'init',
+  builder,
+  handler
+};

--- a/lib/init/init.js
+++ b/lib/init/init.js
@@ -1,0 +1,39 @@
+import { existsSync } from 'fs-extra';
+import logger from '@util/logger';
+
+import cleanupFiles from './utils/clean-up-files';
+import { copyNetwork, copyWithFramework } from './utils/copy-with';
+
+const CWD = process.cwd();
+const BIGTEST_DIR = `${CWD}/bigtest`;
+
+export default async function init({ network, appFramework } = {}) {
+  let bigtestDirExists = existsSync(BIGTEST_DIR);
+  let networkDirExists = existsSync(`${BIGTEST_DIR}/network`);
+  let isCreatingNetwork = !networkDirExists && network;
+
+  if (bigtestDirExists && !isCreatingNetwork) {
+    logger.info('Looks like BigTest is already initialized');
+    return;
+  }
+
+  if (bigtestDirExists && isCreatingNetwork) {
+    await copyNetwork(CWD, appFramework);
+    logger.info('@bigtest/network has been initialized');
+    return;
+  }
+
+  try {
+    let { needsNetwork } = await copyWithFramework(CWD, appFramework, network);
+    let networkMessage = needsNetwork ? 'and @bigtest/mirage' : '';
+
+    logger.info(
+      `BigTest has been initialized with @bigtest/${appFramework} ${networkMessage}`
+    );
+  } catch (error) {
+    logger.error('Initialize failed :(');
+    logger.error(error);
+
+    await cleanupFiles('bigtest', CWD);
+  }
+}

--- a/lib/init/utils/clean-up-files.js
+++ b/lib/init/utils/clean-up-files.js
@@ -1,0 +1,11 @@
+import { remove } from 'fs-extra';
+
+async function cleanupFiles(path, cwd) {
+  try {
+    await remove(`${cwd}/${path}`);
+  } catch (error) {
+    console.log(`Could not clean up files. ${error}`);
+  }
+}
+
+export default cleanupFiles;

--- a/lib/init/utils/copy-with.js
+++ b/lib/init/utils/copy-with.js
@@ -1,0 +1,28 @@
+import { join } from 'path';
+import { copy } from 'fs-extra';
+
+const CLI_TEMPLATE_DIR = join(__dirname, '../../../templates');
+
+export let copyNetwork = async (CWD, framework) => {
+  await copy(`${CLI_TEMPLATE_DIR}/network`, `${CWD}/bigtest/network`);
+  await copy(
+    `${CLI_TEMPLATE_DIR}/helpers/${framework}-network`,
+    `${CWD}/bigtest/helpers`
+  );
+
+  return true;
+};
+
+export let copyWithFramework = async (CWD, framework, needsNetwork) => {
+  await copy(`${CLI_TEMPLATE_DIR}/bigtest`, `${CWD}/bigtest`);
+  await copy(
+    `${CLI_TEMPLATE_DIR}/helpers/${framework}`,
+    `${CWD}/bigtest/helpers`
+  );
+
+  if (needsNetwork) {
+    await copyNetwork(CWD, framework);
+  }
+
+  return { needsNetwork };
+};

--- a/lib/init/utils/copy-with.js
+++ b/lib/init/utils/copy-with.js
@@ -3,7 +3,7 @@ import { copy } from 'fs-extra';
 
 const CLI_TEMPLATE_DIR = join(__dirname, '../../../templates');
 
-export let copyNetwork = async (CWD, framework) => {
+export async function copyNetwork(CWD, framework) {
   await copy(`${CLI_TEMPLATE_DIR}/network`, `${CWD}/bigtest/network`);
   await copy(
     `${CLI_TEMPLATE_DIR}/helpers/${framework}-network`,
@@ -11,9 +11,9 @@ export let copyNetwork = async (CWD, framework) => {
   );
 
   return true;
-};
+}
 
-export let copyWithFramework = async (CWD, framework, needsNetwork) => {
+export async function copyWithFramework(CWD, framework, needsNetwork) {
   await copy(`${CLI_TEMPLATE_DIR}/bigtest`, `${CWD}/bigtest`);
   await copy(
     `${CLI_TEMPLATE_DIR}/helpers/${framework}`,
@@ -25,4 +25,4 @@ export let copyWithFramework = async (CWD, framework, needsNetwork) => {
   }
 
   return { needsNetwork };
-};
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "yarn build:cli && yarn build:assets",
     "build:cli": "babel --out-dir ./dist ./lib --verbose",
     "build:assets": "webpack --config webpack.config.js",
-    "lint": "eslint --ignore-path .gitignore ./",
+    "lint": "eslint ./",
     "postpublish": "bigtest-tag-version",
     "start": "nodemon --watch ./lib --exec 'yarn build'",
     "test": "mocha --opts ./tests/mocha.opts ./tests"

--- a/templates/bigtest/bigtest.opts
+++ b/templates/bigtest/bigtest.opts
@@ -1,0 +1,3 @@
+--serve "yarn start"
+--serve-url "http://localhost:1234"
+--adapter mocha

--- a/templates/bigtest/bigtest.opts
+++ b/templates/bigtest/bigtest.opts
@@ -1,3 +1,3 @@
 --serve "yarn start"
---serve-url "http://localhost:1234"
+--serve.url "http://localhost:1234"
 --adapter mocha

--- a/templates/bigtest/index.js
+++ b/templates/bigtest/index.js
@@ -1,0 +1,5 @@
+// Since we use `async` / `await` we need babel-polyfill
+import 'babel-polyfill';
+
+// import your test files
+import './tests/app-test';

--- a/templates/bigtest/interactors/app.js
+++ b/templates/bigtest/interactors/app.js
@@ -1,0 +1,53 @@
+import {
+  interactor,
+  text,
+  fillable,
+  collection,
+  clickable,
+  triggerable,
+  property,
+  count
+} from '@bigtest/interactor';
+
+@interactor
+class TodoInteractor {
+  titleText = text('h1');
+  fillTodo = fillable('.new-todo');
+  todoCount = count('.todo-list li');
+  completedCount = count('.todo-list .completed');
+  todoCountText = text('.todo-count');
+  activeFilter = text('.filters .selected');
+  clickToggleAll = clickable('.toggle-all');
+  clickClearCompleted = clickable('.clear-completed');
+
+  submitTodo = triggerable('.new-todo', 'keydown', {
+    keyCode: 13
+  });
+
+  todoList = collection('.todo-list li', {
+    toggle: clickable('.toggle'),
+    delete: clickable('.destroy'),
+    todoText: text('label'),
+    isCompleted: property('.toggle', 'checked'),
+    doubleClick: triggerable('label', 'dblclick'),
+    fillInput: fillable('.edit'),
+    pressEnter: triggerable('.edit', 'keydown', {
+      keyCode: 13
+    })
+  });
+
+  clickFilter(filter) {
+    switch (filter) {
+      case 'All':
+        return this.$(`.filters li:first-child button`).click();
+      case 'Active':
+        return this.$(`.filters li:nth-child(2) button`).click();
+      case 'Complete':
+        return this.$(`.filters li:last-child button`).click();
+      default:
+        return false;
+    }
+  }
+}
+
+export default TodoInteractor;

--- a/templates/bigtest/interactors/app.js
+++ b/templates/bigtest/interactors/app.js
@@ -1,53 +1,8 @@
-import {
-  interactor,
-  text,
-  fillable,
-  collection,
-  clickable,
-  triggerable,
-  property,
-  count
-} from '@bigtest/interactor';
+import { interactor, isPresent } from '@bigtest/interactor';
 
 @interactor
-class TodoInteractor {
-  titleText = text('h1');
-  fillTodo = fillable('.new-todo');
-  todoCount = count('.todo-list li');
-  completedCount = count('.todo-list .completed');
-  todoCountText = text('.todo-count');
-  activeFilter = text('.filters .selected');
-  clickToggleAll = clickable('.toggle-all');
-  clickClearCompleted = clickable('.clear-completed');
-
-  submitTodo = triggerable('.new-todo', 'keydown', {
-    keyCode: 13
-  });
-
-  todoList = collection('.todo-list li', {
-    toggle: clickable('.toggle'),
-    delete: clickable('.destroy'),
-    todoText: text('label'),
-    isCompleted: property('.toggle', 'checked'),
-    doubleClick: triggerable('label', 'dblclick'),
-    fillInput: fillable('.edit'),
-    pressEnter: triggerable('.edit', 'keydown', {
-      keyCode: 13
-    })
-  });
-
-  clickFilter(filter) {
-    switch (filter) {
-      case 'All':
-        return this.$(`.filters li:first-child button`).click();
-      case 'Active':
-        return this.$(`.filters li:nth-child(2) button`).click();
-      case 'Complete':
-        return this.$(`.filters li:last-child button`).click();
-      default:
-        return false;
-    }
-  }
+class AppInteractor {
+  hasHeading = isPresent('h1');
 }
 
-export default TodoInteractor;
+export default AppInteractor;

--- a/templates/bigtest/tests/app-test.js
+++ b/templates/bigtest/tests/app-test.js
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { setupApplicationForTesting } from '../helpers/setup-app';
+import { when } from '@bigtest/convergence';
+
+import AppInteractor from '../interactors/app.js';
+
+describe('TodoMVC BigTest example', () => {
+  let TodoApp = new AppInteractor();
+
+  beforeEach(async () => {
+    await setupApplicationForTesting();
+  });
+
+  it('has ten todos to start with', () => {
+    expect(TodoApp.todoCount).to.equal(10);
+  });
+
+  describe('update BigTest install progress', () => {
+    beforeEach(async () => {
+      let completed = new Array(6).fill(null);
+
+      for (let index in completed) {
+        await TodoApp.todoList(parseInt(index, 10)).toggle();
+      }
+
+      await TodoApp.clickActiveFilter();
+    });
+
+    it('has four todos left', () => {
+      expect(TodoApp.todoCount).to.equal(4);
+    });
+
+    it('has the active filter selected', () => {
+      expect(TodoApp.activeFilter).to.equal('Active');
+    });
+
+    describe('adding the final todos with a typo', () => {
+      beforeEach(async () => {
+        await TodoApp.fillTodo('Fill in your interactor').submitTodo();
+        // Interactors are _super_ fast. Users can't add two todos in
+        // 20ms, so lets try to act like a user here and wait for a
+        // todo to be added before adding the next
+        await when(() => TodoApp.todoList().length === 5);
+        await TodoApp.fillTodo('rite tests').submitTodo();
+      });
+
+      it('increases the todo count', () => {
+        expect(TodoApp.todoCount).to.equal(6);
+      });
+
+      it('appends to the list', () => {
+        expect(TodoApp.todoList(4).todoText).to.equal(
+          'Fill in your interactor'
+        );
+        expect(TodoApp.todoList(5).todoText).to.equal('rite tests');
+      });
+
+      describe('fixing the typo', () => {
+        beforeEach(async () => {
+          await TodoApp.todoList(5)
+            .doubleClick()
+            .todoList(5)
+            .fillInput('Write tests')
+            .todoList(5)
+            .pressEnter();
+        });
+
+        it('properly edits the todo item', () => {
+          expect(TodoApp.todoList(5).todoText).to.equal('Write tests');
+        });
+
+        describe('viewing all Todos', () => {
+          beforeEach(async () => {
+            await TodoApp.clickAllFilter();
+          });
+
+          it('selects the right filter', () => {
+            expect(TodoApp.activeFilter).to.equal('All');
+          });
+
+          it('has the correct number of todos', () => {
+            expect(TodoApp.todoCount).to.equal(12);
+            expect(TodoApp.completedCount).to.equal(6);
+          });
+        });
+      });
+    });
+  });
+});

--- a/templates/bigtest/tests/app-test.js
+++ b/templates/bigtest/tests/app-test.js
@@ -1,90 +1,17 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { setupApplicationForTesting } from '../helpers/setup-app';
-import { when } from '@bigtest/convergence';
 
 import AppInteractor from '../interactors/app.js';
 
-describe('TodoMVC BigTest example', () => {
-  let TodoApp = new AppInteractor();
+describe('Your application', () => {
+  let App = new AppInteractor();
 
   beforeEach(async () => {
     await setupApplicationForTesting();
   });
 
-  it('has ten todos to start with', () => {
-    expect(TodoApp.todoCount).to.equal(10);
-  });
-
-  describe('update BigTest install progress', () => {
-    beforeEach(async () => {
-      let completed = new Array(6).fill(null);
-
-      for (let index in completed) {
-        await TodoApp.todoList(parseInt(index, 10)).toggle();
-      }
-
-      await TodoApp.clickActiveFilter();
-    });
-
-    it('has four todos left', () => {
-      expect(TodoApp.todoCount).to.equal(4);
-    });
-
-    it('has the active filter selected', () => {
-      expect(TodoApp.activeFilter).to.equal('Active');
-    });
-
-    describe('adding the final todos with a typo', () => {
-      beforeEach(async () => {
-        await TodoApp.fillTodo('Fill in your interactor').submitTodo();
-        // Interactors are _super_ fast. Users can't add two todos in
-        // 20ms, so lets try to act like a user here and wait for a
-        // todo to be added before adding the next
-        await when(() => TodoApp.todoList().length === 5);
-        await TodoApp.fillTodo('rite tests').submitTodo();
-      });
-
-      it('increases the todo count', () => {
-        expect(TodoApp.todoCount).to.equal(6);
-      });
-
-      it('appends to the list', () => {
-        expect(TodoApp.todoList(4).todoText).to.equal(
-          'Fill in your interactor'
-        );
-        expect(TodoApp.todoList(5).todoText).to.equal('rite tests');
-      });
-
-      describe('fixing the typo', () => {
-        beforeEach(async () => {
-          await TodoApp.todoList(5)
-            .doubleClick()
-            .todoList(5)
-            .fillInput('Write tests')
-            .todoList(5)
-            .pressEnter();
-        });
-
-        it('properly edits the todo item', () => {
-          expect(TodoApp.todoList(5).todoText).to.equal('Write tests');
-        });
-
-        describe('viewing all Todos', () => {
-          beforeEach(async () => {
-            await TodoApp.clickAllFilter();
-          });
-
-          it('selects the right filter', () => {
-            expect(TodoApp.activeFilter).to.equal('All');
-          });
-
-          it('has the correct number of todos', () => {
-            expect(TodoApp.todoCount).to.equal(12);
-            expect(TodoApp.completedCount).to.equal(6);
-          });
-        });
-      });
-    });
+  it('has an h1', () => {
+    expect(App.hasHeading).to.equal(true);
   });
 });

--- a/templates/helpers/react-network/setup-app.js
+++ b/templates/helpers/react-network/setup-app.js
@@ -1,0 +1,23 @@
+import { setupAppForTesting } from '@bigtest/react';
+import startMirage from '../network/start';
+
+// Import your applications root.
+// This is typically what you pass to `ReactDOM.render`
+// import App from '../../src/app.js';
+
+export async function setupApplicationForTesting() {
+  let server, app;
+
+  app = await setupAppForTesting(App, {
+    mountId: 'bigtesting-container',
+    setup: () => {
+      server = startMirage();
+      server.logging = false;
+    },
+    teardown: () => {
+      server.shutdown();
+    }
+  });
+
+  return { app, server };
+}

--- a/templates/helpers/react/setup-app.js
+++ b/templates/helpers/react/setup-app.js
@@ -1,0 +1,11 @@
+import { setupAppForTesting } from '@bigtest/react';
+
+// Import your applications root.
+// This is typically what you pass to `ReactDOM.render`
+// import App from '../../src/app.js';
+
+export async function setupApplicationForTesting() {
+  await setupAppForTesting(App, {
+    mountId: 'bigtesting-container'
+  });
+}

--- a/templates/network/config.js
+++ b/templates/network/config.js
@@ -1,0 +1,8 @@
+export default function configure() {
+  // this.urlPrefix = 'https://my.api.com';
+  // this.namespace = '/v1';
+  //
+  // this.get('/posts', ({ posts }, request) => {
+  //   return posts;
+  // });
+}

--- a/templates/network/factories/index.js
+++ b/templates/network/factories/index.js
@@ -1,0 +1,5 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as post } from './post';

--- a/templates/network/fixtures/index.js
+++ b/templates/network/fixtures/index.js
@@ -1,0 +1,5 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as post } from './post';

--- a/templates/network/force-fetch-polyfill.js
+++ b/templates/network/force-fetch-polyfill.js
@@ -1,0 +1,8 @@
+// This will force fetch to be polyfilled with XHR for pretender to
+// mock http requets.
+//
+// We do this inside of another imported file becuase it needs to happen
+// before the fetch is first imported. Imports are hoisted to the top so
+// settings this explicity before importing the app still won't work; it
+// needs to be inside another import that happens before the app import.
+window.fetch = undefined;

--- a/templates/network/index.js
+++ b/templates/network/index.js
@@ -1,0 +1,8 @@
+let start = () => {};
+
+// Make sure we don't include mirage in production
+if (process.env.NODE_ENV !== 'production') {
+  start = require('./start').default;
+}
+
+export default start;

--- a/templates/network/models/index.js
+++ b/templates/network/models/index.js
@@ -1,0 +1,5 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as post } from './post';

--- a/templates/network/scenarios/default.js
+++ b/templates/network/scenarios/default.js
@@ -1,0 +1,4 @@
+export default function defaultScenario(/* server */) {
+  // Create server data by default
+  // server.createList("post", 10);
+}

--- a/templates/network/scenarios/index.js
+++ b/templates/network/scenarios/index.js
@@ -1,0 +1,6 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as Post } from './post';
+export { default } from './default';

--- a/templates/network/serializers/index.js
+++ b/templates/network/serializers/index.js
@@ -1,0 +1,5 @@
+// When you add a new file to this directory make sure you import &
+// export it in this index
+
+// For example:
+// export { default as post } from './post';

--- a/templates/network/start.js
+++ b/templates/network/start.js
@@ -1,0 +1,41 @@
+import Mirage, { camelize } from '@bigtest/mirage';
+
+import baseConfig from './config';
+import './force-fetch-polyfill';
+
+import * as scenarios from './scenarios';
+import * as factories from './factories';
+// import * as fixtures from './fixtures';
+// import * as models from './models';
+// import * as serializers from './serializers';
+
+const environment = process.env.NODE_ENV;
+
+export default function startMirage(...scenarioNames) {
+  let server = new Mirage({
+    // Uncomment these imports if you add files
+    //
+    // factories,
+    // fixtures,
+    // models,
+    // serializers,
+    scenarios,
+    environment,
+    baseConfig
+  });
+
+  // mirage does not load our factories outside of testing when we do
+  // not declare a default scenario, so we load them ourselves
+  if (environment !== 'test') {
+    server.loadFactories(factories);
+  }
+
+  // mirage only loads a `default` scenario for us out of the box, so
+  // instead we run any scenarios after we initialize mirage
+  scenarioNames.filter(Boolean).forEach(scenarioName => {
+    let scenario = scenarios[camelize(scenarioName)];
+    if (scenario) scenario(server);
+  });
+
+  return server;
+}

--- a/tests/acceptance/init/default-test.js
+++ b/tests/acceptance/init/default-test.js
@@ -41,11 +41,9 @@ describe('Acceptance: `bigtest init`', () => {
         'utf-8'
       );
 
-      expect(
-        helperFile.includes(
-          "import { setupAppForTesting } from '@bigtest/react';"
-        )
-      ).to.equal(true);
+      expect(helperFile).to.include(
+        "import { setupAppForTesting } from '@bigtest/react';"
+      );
     });
   });
 
@@ -78,12 +76,10 @@ describe('Acceptance: `bigtest init`', () => {
         'utf-8'
       );
 
-      expect(
-        helperFile.includes(
-          "import { setupAppForTesting } from '@bigtest/react';"
-        )
-      ).to.equal(true);
-      expect(helperFile.includes('server = startMirage();')).to.equal(true);
+      expect(helperFile).to.include(
+        "import { setupAppForTesting } from '@bigtest/react';"
+      );
+      expect(helperFile).to.include('server = startMirage();');
     });
   });
 

--- a/tests/acceptance/init/default-test.js
+++ b/tests/acceptance/init/default-test.js
@@ -1,7 +1,7 @@
 import { pathExists, readFile } from 'fs-extra';
 import { expect, bigtest } from '../helpers';
 import { describe, it, afterEach, beforeEach } from 'mocha';
-import cleanupFiles from '../../../lib/init/utils/clean-up-files';
+import cleanupFiles from '@init/utils/clean-up-files';
 
 const CWD = process.cwd();
 

--- a/tests/acceptance/init/default-test.js
+++ b/tests/acceptance/init/default-test.js
@@ -18,8 +18,8 @@ describe('Acceptance: `bigtest init`', () => {
     });
 
     it('outputs the right message to the console', () => {
-      expect(result.stdout.toString()).to.equal(
-        '\nBigTest has been initialized with @bigtest/react \n\n'
+      expect(result.stdout.toString()).to.include(
+        'BigTest has been initialized with @bigtest/react'
       );
     });
 
@@ -59,8 +59,8 @@ describe('Acceptance: `bigtest init`', () => {
     });
 
     it('outputs the right message to the console', () => {
-      expect(result.stdout.toString()).to.equal(
-        '\nBigTest has been initialized with @bigtest/react and @bigtest/mirage\n\n'
+      expect(result.stdout.toString()).to.include(
+        'BigTest has been initialized with @bigtest/react and @bigtest/mirage'
       );
     });
 
@@ -100,8 +100,8 @@ describe('Acceptance: `bigtest init`', () => {
       });
 
       it('outputs the right message to the console', () => {
-        expect(result.stdout.toString()).to.equal(
-          '\nLooks like BigTest is already initialized\n\n'
+        expect(result.stdout.toString()).to.include(
+          'Looks like BigTest is already initialized'
         );
       });
     });
@@ -116,8 +116,8 @@ describe('Acceptance: `bigtest init`', () => {
       });
 
       it('outputs the right message to the console', () => {
-        expect(result.stdout.toString()).to.equal(
-          '\n@bigtest/network has been initialized\n\n'
+        expect(result.stdout.toString()).to.include(
+          '@bigtest/network has been initialized'
         );
       });
     });

--- a/tests/acceptance/init/default-test.js
+++ b/tests/acceptance/init/default-test.js
@@ -1,19 +1,16 @@
-import { expect } from 'chai';
-import { promisify } from 'util';
 import { pathExists, readFile } from 'fs-extra';
-import { execFile } from 'child_process';
+import { expect, bigtest } from '../helpers';
 import { describe, it, afterEach, beforeEach } from 'mocha';
-import cleanupFiles from '../../lib/init/utils/clean-up-files';
+import cleanupFiles from '../../../lib/init/utils/clean-up-files';
 
 const CWD = process.cwd();
-let exec = promisify(execFile);
 
-describe('bigtest init', () => {
-  describe('default init', function() {
+describe('Acceptance: `bigtest init`', () => {
+  describe('bigtest init', () => {
     let result;
 
-    beforeEach(async function() {
-      result = await exec('node', ['./index.js', 'init']);
+    beforeEach(async () => {
+      result = await bigtest('init');
     });
 
     afterEach(async () => {
@@ -21,24 +18,24 @@ describe('bigtest init', () => {
     });
 
     it('outputs the right message to the console', () => {
-      expect(result.stdout).to.equal(
+      expect(result.stdout.toString()).to.equal(
         '\nBigTest has been initialized with @bigtest/react \n\n'
       );
     });
 
-    it('creates a bigtest folder', async function() {
+    it('creates a bigtest folder', async () => {
       let hasBigtestFolder = await pathExists(`${CWD}/bigtest`);
 
       expect(hasBigtestFolder).to.equal(true);
     });
 
-    it('does not create a bigtest network folder', async function() {
+    it('does not create a bigtest network folder', async () => {
       let hasNetworkFolder = await pathExists(`${CWD}/bigtest/network`);
 
       expect(hasNetworkFolder).to.equal(false);
     });
 
-    it('inits with @bigtest/react', async function() {
+    it('inits with @bigtest/react', async () => {
       let helperFile = await readFile(
         `${CWD}/bigtest/helpers/setup-app.js`,
         'utf-8'
@@ -52,11 +49,11 @@ describe('bigtest init', () => {
     });
   });
 
-  describe('bigtest init with network', function() {
+  describe('bigtest init with network', () => {
     let result;
 
-    beforeEach(async function() {
-      result = await exec('node', ['./index.js', 'init', '--network']);
+    beforeEach(async () => {
+      result = await bigtest('init --network');
     });
 
     afterEach(async () => {
@@ -64,18 +61,18 @@ describe('bigtest init', () => {
     });
 
     it('outputs the right message to the console', () => {
-      expect(result.stdout).to.equal(
+      expect(result.stdout.toString()).to.equal(
         '\nBigTest has been initialized with @bigtest/react and @bigtest/mirage\n\n'
       );
     });
 
-    it('creates a bigtest network folder', async function() {
+    it('creates a bigtest network folder', async () => {
       let hasNetworkFolder = await pathExists(`${CWD}/bigtest/network`);
 
       expect(hasNetworkFolder).to.equal(true);
     });
 
-    it('inits @bigtest/react helper with @bigtest/mirage setup', async function() {
+    it('inits @bigtest/react helper with @bigtest/mirage setup', async () => {
       let helperFile = await readFile(
         `${CWD}/bigtest/helpers/setup-app.js`,
         'utf-8'
@@ -90,16 +87,16 @@ describe('bigtest init', () => {
     });
   });
 
-  describe('bigtest init with an existing directory', function() {
+  describe('bigtest init with an existing directory', () => {
     let result;
 
-    beforeEach(async function() {
-      await exec('node', ['./index.js', 'init']);
+    beforeEach(async () => {
+      await bigtest('init');
     });
 
-    describe('without network', function() {
-      beforeEach(async function() {
-        result = await exec('node', ['./index.js', 'init']);
+    describe('without network', () => {
+      beforeEach(async () => {
+        result = await bigtest('init');
       });
 
       afterEach(async () => {
@@ -107,15 +104,15 @@ describe('bigtest init', () => {
       });
 
       it('outputs the right message to the console', () => {
-        expect(result.stdout).to.equal(
+        expect(result.stdout.toString()).to.equal(
           '\nLooks like BigTest is already initialized\n\n'
         );
       });
     });
 
-    describe('with network', function() {
-      beforeEach(async function() {
-        result = await exec('node', ['./index.js', 'init', '--network']);
+    describe('with network', () => {
+      beforeEach(async () => {
+        result = await bigtest('init --network');
       });
 
       afterEach(async () => {
@@ -123,7 +120,7 @@ describe('bigtest init', () => {
       });
 
       it('outputs the right message to the console', () => {
-        expect(result.stdout).to.equal(
+        expect(result.stdout.toString()).to.equal(
           '\n@bigtest/network has been initialized\n\n'
         );
       });

--- a/tests/unit/init-test.js
+++ b/tests/unit/init-test.js
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import { promisify } from 'util';
+import { pathExists, readFile } from 'fs-extra';
+import { execFile } from 'child_process';
+import { describe, it, afterEach, beforeEach } from 'mocha';
+import cleanupFiles from '../../lib/init/utils/clean-up-files';
+
+const CWD = process.cwd();
+let exec = promisify(execFile);
+
+describe('bigtest init', () => {
+  describe('default init', function() {
+    let result;
+
+    beforeEach(async function() {
+      result = await exec('node', ['./index.js', 'init']);
+    });
+
+    afterEach(async () => {
+      await cleanupFiles('bigtest', CWD);
+    });
+
+    it('outputs the right message to the console', () => {
+      expect(result.stdout).to.equal(
+        '\nBigTest has been initialized with @bigtest/react \n\n'
+      );
+    });
+
+    it('creates a bigtest folder', async function() {
+      let hasBigtestFolder = await pathExists(`${CWD}/bigtest`);
+
+      expect(hasBigtestFolder).to.equal(true);
+    });
+
+    it('does not create a bigtest network folder', async function() {
+      let hasNetworkFolder = await pathExists(`${CWD}/bigtest/network`);
+
+      expect(hasNetworkFolder).to.equal(false);
+    });
+
+    it('inits with @bigtest/react', async function() {
+      let helperFile = await readFile(
+        `${CWD}/bigtest/helpers/setup-app.js`,
+        'utf-8'
+      );
+
+      expect(
+        helperFile.includes(
+          "import { setupAppForTesting } from '@bigtest/react';"
+        )
+      ).to.equal(true);
+    });
+  });
+
+  describe('bigtest init with network', function() {
+    let result;
+
+    beforeEach(async function() {
+      result = await exec('node', ['./index.js', 'init', '--network']);
+    });
+
+    afterEach(async () => {
+      await cleanupFiles('bigtest', CWD);
+    });
+
+    it('outputs the right message to the console', () => {
+      expect(result.stdout).to.equal(
+        '\nBigTest has been initialized with @bigtest/react and @bigtest/mirage\n\n'
+      );
+    });
+
+    it('creates a bigtest network folder', async function() {
+      let hasNetworkFolder = await pathExists(`${CWD}/bigtest/network`);
+
+      expect(hasNetworkFolder).to.equal(true);
+    });
+
+    it('inits @bigtest/react helper with @bigtest/mirage setup', async function() {
+      let helperFile = await readFile(
+        `${CWD}/bigtest/helpers/setup-app.js`,
+        'utf-8'
+      );
+
+      expect(
+        helperFile.includes(
+          "import { setupAppForTesting } from '@bigtest/react';"
+        )
+      ).to.equal(true);
+      expect(helperFile.includes('server = startMirage();')).to.equal(true);
+    });
+  });
+
+  describe('bigtest init with an existing directory', function() {
+    let result;
+
+    beforeEach(async function() {
+      await exec('node', ['./index.js', 'init']);
+    });
+
+    describe('without network', function() {
+      beforeEach(async function() {
+        result = await exec('node', ['./index.js', 'init']);
+      });
+
+      afterEach(async () => {
+        await cleanupFiles('bigtest', CWD);
+      });
+
+      it('outputs the right message to the console', () => {
+        expect(result.stdout).to.equal(
+          '\nLooks like BigTest is already initialized\n\n'
+        );
+      });
+    });
+
+    describe('with network', function() {
+      beforeEach(async function() {
+        result = await exec('node', ['./index.js', 'init', '--network']);
+      });
+
+      afterEach(async () => {
+        await cleanupFiles('bigtest', CWD);
+      });
+
+      it('outputs the right message to the console', () => {
+        expect(result.stdout).to.equal(
+          '\n@bigtest/network has been initialized\n\n'
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What is this?

This implements the first `@bigtest/cli` command: `init`. `init` will scaffold the directories needed to get started with BigTest in your project. There are two arguments to the command:

- **`--network`** - When present the cli will generate the network directory and all of the appropriate sub-directories
- **`--app-framework`**  - Currently only supports the string `react`. In the future this will generate the proper BigTest application framework helpers you need to render your app. 

### TODOs

- [x] Learn how to test a CLI
- [x] Format logs to the CLI to look better
- [x] Have a working implementation out of the box for `@bigtest/mirage`
- [x] If `init` command fails, roll back any files that were created
- [x] Create TODO MVC app to run through tests 
- [x] Fill out example interactors
- [x] Fill out example tests

# Gif
![2018-08-11 16 15 32](https://user-images.githubusercontent.com/2072894/43996134-f3e8dc6a-9d81-11e8-96bf-b237756f11f2.gif)
