### PR TITLE
Fix child process error

### DIFF
--- a/lib/run/browsers/base.js
+++ b/lib/run/browsers/base.js
@@ -85,14 +85,9 @@ export default class BaseBrowser extends ChildProcess {
     await this.setup();
 
     // resolves when done running
-    this.run().catch(err => {
-      error = err;
-    });
+    this.run().catch(err => { error = err; });
 
-    // wait until we're running
-    await when(() => this.running || error);
-
-    // reject if an error was encountered
-    if (error) throw error;
+    // wait until we start running, or encounter an error
+    await when(() => this.running || (!!error && throw error));
   }
 }

--- a/lib/run/process.js
+++ b/lib/run/process.js
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'child_process';
-import { pathExists } from 'fs-extra';
+import { existsSync } from 'fs-extra';
 import { when } from '@bigtest/convergence';
 
 import { hasDescriptor } from './util/common';
@@ -74,7 +74,7 @@ export default class ChildProcess {
 
     // find the first existing path or bin
     let cmd = [].concat(this.command)
-      .find(c => /\\|\//.test(c) ? pathExists(c) : binExists(c));
+      .find(c => /\\|\//.test(c) ? existsSync(c) : binExists(c));
     let args = this.arguments || [];
 
     if (!cmd) {

--- a/lib/run/process.js
+++ b/lib/run/process.js
@@ -27,8 +27,7 @@ export default class ChildProcess {
     args
   } = {}) {
     let properties = {
-      piped: new Map(),
-      running: false
+      piped: new Map()
     };
 
     if (!hasDescriptor(this, 'command')) {
@@ -48,6 +47,14 @@ export default class ChildProcess {
     }
 
     assign(this, properties);
+  }
+
+  /**
+   * True when there is a running process
+   * @property {Boolean}
+   */
+  get running() {
+    return !!(this.process && this.process.kill(0));
   }
 
   /**
@@ -76,23 +83,43 @@ export default class ChildProcess {
 
     let env = assign({}, process.env, this.env);
 
-    // hangs around until the process closes
+    // hangs around until the process exits and closes
     return new Promise((resolve, reject) => {
-      this.process = spawn(cmd, args, { env });
-      this.running = true;
+      let exited, closed;
 
-      this.process.once('error', reject);
+      let done = err => {
+        if (err || (exited && closed)) {
+          this.process.removeListener('exit', handleExit);
+          this.process.removeListener('close', handleClose);
+          this.process.removeListener('error', done);
+          this.process = null;
 
-      this.process.once('exit', code => {
-        if (code > 0) {
-          reject(new Error(`${cmd} failed with exit code ${code}`));
+          if (err) {
+            reject(err);
+          } else if (exited && closed) {
+            resolve();
+          }
         }
-      });
+      };
 
-      this.process.once('close', () => {
-        this.running = false;
-        resolve();
-      });
+      let handleExit = code => {
+        if (code > 0) {
+          done(new Error(`${cmd} failed with exit code ${code}`));
+        } else {
+          exited = true;
+          done();
+        }
+      };
+
+      let handleClose = () => {
+        closed = true;
+        done();
+      };
+
+      this.process = spawn(cmd, args, { env });
+      this.process.once('exit', handleExit);
+      this.process.once('close', handleClose);
+      this.process.once('error', done);
     });
   }
 
@@ -155,7 +182,7 @@ export default class ChildProcess {
    * @param {Writable} stream - stream to pipe
    */
   _pipe(name, stream) {
-    if (!this.piped.has(stream)) {
+    if (this.process && !this.piped.has(stream)) {
       let meta = { output: false };
       let listener = data => {
         if (!meta.output) {
@@ -168,6 +195,7 @@ export default class ChildProcess {
 
       assign(meta, { listener });
       this.piped.set(stream, meta);
+
       this.process[name].on('data', listener);
     }
   }
@@ -184,9 +212,12 @@ export default class ChildProcess {
     if (this.piped.has(stream)) {
       let { output, listener } = this.piped.get(stream);
 
-      stream.write(output ? '\n' : '');
-      this.process[name].removeListener('data', listener);
       this.piped.delete(stream);
+      stream.write(output ? '\n' : '');
+
+      if (this.process) {
+        this.process[name].removeListener('data', listener);
+      }
     }
   }
 }

--- a/lib/run/util/common.js
+++ b/lib/run/util/common.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { pathExists } from 'fs-extra';
+import { existsSync } from 'fs-extra';
 
 const {
   assign,
@@ -59,7 +59,7 @@ export function getDescriptors(obj) {
  */
 export function maybeResolveLocal(dir, name) {
   let local = path.join(__dirname, `../${dir}/${name}.js`);
-  let module = pathExists(local) ? local : null;
+  let module = existsSync(local) ? local : null;
 
   // if not local, try to resolve the name directly
   try { module = module || require.resolve(name); } catch (e) {}

--- a/tests/unit/run/process-test.js
+++ b/tests/unit/run/process-test.js
@@ -89,6 +89,11 @@ describe('Unit: Process', () => {
       let test = new Process({ name: 'nope', cmd: 'f4k3' });
       await expect(test.run()).to.be.rejectedWith('command not found for nope');
     });
+
+    it('rejects when the command path does not exist', async () => {
+      let test = new Process({ name: 'path', cmd: 'not/a/real/path' });
+      await expect(test.run()).to.be.rejectedWith('command not found for path');
+    });
   });
 
   describe('kill', () => {


### PR DESCRIPTION
## Purpose

My Google Chrome location recently changed and it caused the `run` command to not be able to launch the browser.

I should have received an error about the Chrome command, but did not. This was because the error implementation is seemingly impossible to test with the way the rest of that process method is written.

The only way to test it is with a command that doesn't exist... but we supposedly catch commands that don't exist already.

Turns out it was because `pathExists` was returning a truthy value even when the path did not exist... because `pathExists` returns a promise  🤦‍♂️ 

## Approach

The actual fix was as easy as replacing `pathExists` with `existsSync`, and a test for that was added to the child process tests.

The error handling, while changed to surface this issue, still seemingly cannot be tested so long as we catch non-existent commands.