### PR TITLE
[v0.1.1] Include the `index.js` file when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@bigtest/cli",
   "description": "Command line interface for testing big",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "main": "dist",
   "files": [
+    "index.js",
     "dist",
     "docs",
     "src"


### PR DESCRIPTION
## What is this? 
We were not explicitly allowing the index file to be included with published npm files. This causes the CLI to fail to run since the index file is the entry point of the CLI.