### PR TITLE
Change webserver host arguments to hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- `client-host` and `proxy-host` to `client-hostname` and
+  `proxy-hostname`.
+
 ## [0.2.0] - 2018-09-14
 
 ### Changed

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -70,7 +70,7 @@ function builder(yargs) {
         }
       }
     })
-    .option('client-host', {
+    .option('client-hostname', {
       group: 'Client Options:',
       description: 'Client server host name',
       requiresArg: true,
@@ -84,7 +84,7 @@ function builder(yargs) {
       type: 'number',
       default: 4567
     })
-    .option('proxy-host', {
+    .option('proxy-hostname', {
       group: 'Proxy Options:',
       description: 'Proxy server host name',
       requiresArg: true,
@@ -148,15 +148,15 @@ function handler(argv) {
     once: !!argv.once,
     // Client Options:
     client: argv.client || {
-      //   --client-host  string
-      host: argv.clientHost,
+      //   --client-hostname  string
+      hostname: argv.clientHostname,
       //   --client-port  string
       port: argv.clientPort
     },
     // Proxy Options:
     proxy: argv.proxy || {
-      //   --proxy-host  string
-      host: argv.proxyHost,
+      //   --proxy-hostname  string
+      hostname: argv.proxyHostname,
       //   --proxy-port  string
       port: argv.proxyPort
     },

--- a/tests/acceptance/run/default-test.js
+++ b/tests/acceptance/run/default-test.js
@@ -20,12 +20,12 @@ describe('Acceptance: `bigtest run`', () => {
         --help                       Show help  [boolean]
 
       Client Options:
-        --client-host  Client server host name  [string] [default: "localhost"]
-        --client-port  Client server port number  [number] [default: 4567]
+        --client-hostname  Client server host name  [string] [default: "localhost"]
+        --client-port      Client server port number  [number] [default: 4567]
 
       Proxy Options:
-        --proxy-host  Proxy server host name  [string] [default: "localhost"]
-        --proxy-port  Proxy server port number  [number] [default: 5678]
+        --proxy-hostname  Proxy server host name  [string] [default: "localhost"]
+        --proxy-port      Proxy server port number  [number] [default: 5678]
 
       Serve Options:
         -s, --serve     App server command  [string]


### PR DESCRIPTION
## Purpose

The `Server` classes expect `hostname` and `port` but the CLI passes through `host` and `port`.

## Approach

`host` is supposed to include the port number, so we should go with `hostname` since that's what we really mean for these options.