### PR TITLE
Serve-url bug

### DIFF
--- a/templates/bigtest/bigtest.opts
+++ b/templates/bigtest/bigtest.opts
@@ -1,3 +1,3 @@
 --serve "yarn start"
---serve.url "http://localhost:1234"
+--serve-url "http://localhost:1234"
 --adapter mocha


### PR DESCRIPTION
The serve url currently initializes using dot notation which breaks the test when you try to run them. 

> `--serve.url "http://localhost:1234"` 

This PR switches that serve url to dash notation which allows the tests to be ran successfully. 