### PR TITLE
Change NODE_ENV from 'testing' to 'test' for the --serve plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- the `--serve` plugin now automatically sets `NODE_ENV` environment variable to "test" instead of "testing"
+
 ## [0.2.2] - 2018-09-26
+
+### Fixed
 
 - fixed `bigtest.opts` init template to use dash-cased options instead
   of dot notation. See [#20](https://github.com/bigtestjs/cli/pull/20) for more.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ _Under **heavy** development_
 
 1. Change your bundler's entry to point to your tests
 ``` javascript
-// `bigtest run` sets NODE_ENV to "testing" automatically
-let isTesting = process.env.NODE_ENV === 'testing'
+// `bigtest run` sets NODE_ENV to "test" automatically
+let isTesting = process.env.NODE_ENV === 'test'
 
 // if your bundler supports multiple entry points, you can include all
 // of your tests using a glob pattern (see node-glob)

--- a/lib/run/plugins/serve.js
+++ b/lib/run/plugins/serve.js
@@ -37,7 +37,7 @@ export default class ServePlugin extends BasePlugin {
       name: 'Serve',
       env: assign({
         FORCE_COLOR: true,
-        NODE_ENV: 'testing'
+        NODE_ENV: 'test'
       }, env),
       cmd,
       args

--- a/tests/unit/run/plugins/serve-test.js
+++ b/tests/unit/run/plugins/serve-test.js
@@ -62,7 +62,7 @@ describe('Unit: Plugins - Serve', () => {
     it('initializes a child process with provided env vars plus defaults', () => {
       expect(test.serve.env).to.deep.equal({
         FORCE_COLOR: true,
-        NODE_ENV: 'testing',
+        NODE_ENV: 'test',
         FOO: 'BAR'
       });
     });


### PR DESCRIPTION
Currently when using the `--serve` cli argument, it automatically sets the `NODE_ENV` environment variable to "testing".

This PR changes it to "test" in order to be more in line with other testing frameworks and tools (like mirage).